### PR TITLE
[WIP] Add ability to report errors

### DIFF
--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -206,7 +206,7 @@ final class MainWindowController: NSWindowController {
 					case .cancelled:
 						break
 					default:
-						self.presentError(error, modalFor: self.window)
+						self.presentError(SoftError(error), modalFor: self.window)
 					}
 
 					return


### PR DESCRIPTION
Swift errors are super annoying as by default they don't capture any context. So I have gone with a generic wrapper error that stores the original error and a lot of metadata. The error, when presented, also includes a `Report…` button:

<img width="472" alt="screen shot 2019-01-29 at 17 07 38" src="https://user-images.githubusercontent.com/170270/51902354-66797280-23ec-11e9-8f91-d9797d91e241.png">

The reason the error reporting functionality is in the error itself is that we control when an error is presented anyway, and this way it forces us to wrap it in a `SoftError` which captures more context.

I would very much like this to be simpler, but I've failed to come up with a better way to handle this. Suggestions welcome.

When the user clicks the `Report…` button, it opens a new GitHub issue with lots of information about the error. [Example.](https://github.com/sindresorhus/gifski-app/issues/new?body=%0A%0A%0A%3C%21--%0AInclude%20any%20additional%20information%20above.%20For%20example%2C%20steps%20to%20reproduce%20the%20issue.%0A%0AIf%20you%20don%27t%20have%20a%20GitHub%20account%2C%20you%20can%20report%20this%20issue%20at%20https%3A//sindresorhus.com/feedback/?product%3DGifski%0A--%3E%0A%0A-------------------------------------------%0A%0A%23%23%23%23%23%23%20Error%0A%3E%20Failed%20to%20write%20to%20output%2C%20with%20underlying%20error%3A%20Should%20not%20happen%2C%20file%20a%20bug%3A%20https%3A//github.com/ImageOptim/gifski%0A%0A%23%23%23%23%23%23%20Type%0A%3E%20%60writeFailed%28Gifski.GifskiWrapperError.other%29%60%0A%0A%23%23%23%23%23%23%20Location%0A%3E%20%60startConversion%28inputUrl%3AoutputUrl%3A%29%60%20at%20MainWindowController%3A175%0A%0A%23%23%23%23%23%23%20Stack%20Trace%0A%60%60%60%0A0%20%20%20Gifski%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00000001000390de%20%24S6Gifski12ErrorContextV5error8function4file4line6columnACs0B0_p_S2SS2itcfC%20%2B%201150%0A1%20%20%20Gifski%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x0000000100039c91%20%24S6Gifski9SoftErrorV_8function4file4line6columnACs0C0_p_S2SS2itcfC%20%2B%201585%0A2%20%20%20Gifski%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x0000000100065fba%20%24S6Gifski20MainWindowControllerC15startConversion8inputUrl06outputH0y10Foundation3URLV_AItFyyXEfU0_yA2AC5ErrorOSgcfU_%20%2B%20330%0A3%20%20%20Gifski%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x0000000100066c55%20%24S6Gifski20MainWindowControllerC15startConversion8inputUrl06outputH0y10Foundation3URLV_AItFyyXEfU0_yA2AC5ErrorOSgcfU_TA%20%2B%2021%0A4%20%20%20Gifski%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x0000000100046fa3%20%24S6GifskiAAC3run_17completionHandleryAB10ConversionV_yAB5ErrorOSgcSgtFZyAIcfU_yycfU_%20%2B%20115%0A5%20%20%20Gifski%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x0000000100048bfa%20%24S6GifskiAAC3run_17completionHandleryAB10ConversionV_yAB5ErrorOSgcSgtFZyAIcfU_yycfU_TA%20%2B%2026%0A6%20%20%20Gifski%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x000000010000d56d%20%24SIeg_IeyB_TR%20%2B%2045%0A7%20%20%20libdispatch.dylib%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00000001017866eb%20_dispatch_call_block_and_release%20%2B%2012%0A8%20%20%20libdispatch.dylib%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00000001017877c3%20_dispatch_client_callout%20%2B%208%0A9%20%20%20libdispatch.dylib%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x0000000101796390%20_dispatch_main_queue_callback_4CF%20%2B%201909%0A10%20%20CoreFoundation%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff518641ab%20__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__%20%2B%209%0A11%20%20CoreFoundation%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff518638ba%20__CFRunLoopRun%20%2B%202335%0A12%20%20CoreFoundation%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff51862d48%20CFRunLoopRunSpecific%20%2B%20463%0A13%20%20HIToolbox%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff50af9ab5%20RunCurrentEventLoopInMode%20%2B%20293%0A14%20%20HIToolbox%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff50af97eb%20ReceiveNextEventCommon%20%2B%20618%0A15%20%20HIToolbox%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff50af9568%20_BlockUntilNextEventMatchingListInModeWithFilter%20%2B%2064%0A16%20%20AppKit%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff4edb4363%20_DPSNextEvent%20%2B%20997%0A17%20%20AppKit%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff4edb3102%20-%5BNSApplication%28NSEvent%29%20_nextEventMatchingEventMask%3AuntilDate%3AinMode%3Adequeue%3A%5D%20%2B%201362%0A18%20%20AppKit%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff4edad165%20-%5BNSApplication%20run%5D%20%2B%20699%0A19%20%20AppKit%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff4ed9c8a3%20NSApplicationMain%20%2B%20780%0A20%20%20Gifski%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x0000000100068fed%20main%20%2B%2013%0A21%20%20libdyld.dylib%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x00007fff7eab4ed9%20start%20%2B%201%0A22%20%20???%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%200x0000000000000003%200x0%20%2B%203%0A%60%60%60%0A%0A%0A---%0AGifski%201.4.1%20%2811%29%0AmacOS%2010.14.3%0AMacBookPro11%2C3)