### PR TITLE
Improve the error message alert panel

### DIFF
--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -28,6 +28,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		if urlsToConvertOnLaunch != nil {
 			mainWindowController.convert(urlsToConvertOnLaunch)
 		}
+
+		// TEMP for testing
+		NSAlert.showModalAndReportToCrashlytics(
+			message: "The video file is not supported.",
+			informativeText: "Please open an issue on https://github.com/sindresorhus/gifski-app or email sindresorhus@gmail.com. ZIP the video and attach it.\n\nInclude this info:",
+			debugInfo: "TEST"
+		)
 	}
 
 	func application(_ application: NSApplication, open urls: [URL]) {

--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -29,13 +29,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		if urlsToConvertOnLaunch != nil {
 			mainWindowController.convert(urlsToConvertOnLaunch)
 		}
-
-		// TEMP for testing
-		NSAlert.showModalAndReportToCrashlytics(
-			message: "The video file is not supported.",
-			informativeText: "Please open an issue on https://github.com/sindresorhus/gifski-app or email sindresorhus@gmail.com. ZIP the video and attach it.\n\nInclude this info:",
-			debugInfo: "TEST"
-		)
 	}
 
 	func application(_ application: NSApplication, open urls: [URL]) {

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -141,11 +141,10 @@ final class MainWindowController: NSWindowController {
 		}
 
 		if asset.hasAudio && !asset.hasVideo {
-			NSAlert.showModalAndReportToCrashlytics(
+			NSAlert.showModal(
 				for: window,
 				message: "Audio files are not supported.",
-				informativeText: "Gifski converts video files but the provided file is audio-only. Please provide a file that contains video.",
-				debugInfo: asset.debugInfo
+				informativeText: "Gifski converts video files but the provided file is audio-only. Please provide a file that contains video."
 			)
 
 			return

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -155,7 +155,7 @@ final class MainWindowController: NSWindowController {
 			NSAlert.showModalAndReportToCrashlytics(
 				for: window,
 				message: "The video file is not supported.",
-				informativeText: "Please open an issue on https://github.com/sindresorhus/gifski-app or email sindresorhus@gmail.com. ZIP the video and attach it.\n\nInclude this info:\n\(asset.debugInfo)",
+				informativeText: "Please open an issue on https://github.com/sindresorhus/gifski-app or email sindresorhus@gmail.com. ZIP the video and attach it.\n\nInclude this info:",
 				debugInfo: asset.debugInfo
 			)
 
@@ -166,7 +166,7 @@ final class MainWindowController: NSWindowController {
 			NSAlert.showModalAndReportToCrashlytics(
 				for: window,
 				message: "The video metadata is not readable.",
-				informativeText: "Please open an issue on https://github.com/sindresorhus/gifski-app or email sindresorhus@gmail.com. ZIP the video and attach it.\n\nInclude this info:\n\(asset.debugInfo)",
+				informativeText: "Please open an issue on https://github.com/sindresorhus/gifski-app or email sindresorhus@gmail.com. ZIP the video and attach it.\n\nInclude this info:",
 				debugInfo: asset.debugInfo
 			)
 
@@ -181,7 +181,7 @@ final class MainWindowController: NSWindowController {
 			NSAlert.showModalAndReportToCrashlytics(
 				for: window,
 				message: "The video dimensions must be at least 10×10.",
-				informativeText: "The dimensions of your video are \(asset.dimensions?.formatted ?? "0×0").\n\nIf you think this error is a mistake, please open an issue on https://github.com/sindresorhus/gifski-app or email sindresorhus@gmail.com. ZIP the video and attach it.\n\nInclude this info:\n\(asset.debugInfo)",
+				informativeText: "The dimensions of your video are \(asset.dimensions?.formatted ?? "0×0").\n\nIf you think this error is a mistake, please open an issue on https://github.com/sindresorhus/gifski-app or email sindresorhus@gmail.com. ZIP the video and attach it.\n\nInclude this info:",
 				debugInfo: asset.debugInfo
 			)
 

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -306,16 +306,28 @@ extension NSAlert {
 				scrollView.translatesAutoresizingMaskIntoConstraints = false
 				scrollView.heightAnchor.constraint(equalToConstant: 120).isActive = true
 
+				// Alternative solution
+//				scrollView.frame = CGRect(width: 300, height: 120)
+//				scrollView.onAddedToSuperview {
+//					if let messageTextField = (scrollView.superview?.superview?.subviews.first { $0 is NSTextField }) {
+//						scrollView.frame.width = messageTextField.frame.width
+//					} else {
+//						assertionFailure("Couldn't detect the message textfield view of the NSAlert panel")
+//					}
+//				}
+
 				scrollView.onAddedToSuperview {
-					print("added")
-					scrollView.leftAnchor.constraint(equalTo: scrollView.superview!.leftAnchor).isActive = true
-					scrollView.rightAnchor.constraint(equalTo: scrollView.superview!.rightAnchor).isActive = true
+					if let messageTextField = (scrollView.superview?.superview?.subviews.first { $0 is NSTextField }) {
+						scrollView.bottomAnchor.constraint(equalTo: scrollView.superview!.bottomAnchor).isActive = true
+						scrollView.leftAnchor.constraint(equalTo: scrollView.superview!.leftAnchor).isActive = true
+						scrollView.widthAnchor.constraint(equalTo: messageTextField.widthAnchor).isActive = true
+					}
 				}
 
 				// FOR DEBUGGING
 				scrollView.drawsBackground = true
 				scrollView.backgroundColor = .red
-				// scrollView.frame = CGRect(width: 100, height: 100)
+				//scrollView.frame = CGRect(width: 100, height: 100)
 
 				let textView = scrollView.documentView as! NSTextView
 				textView.drawsBackground = false

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -266,32 +266,15 @@ extension NSAlert {
 		if let detailText = detailText {
 			if #available(macOS 10.14, *) {
 				let scrollView = NSTextView.scrollableTextView()
-				//scrollView.frame = CGRect(width: 300, height: 120)
-				scrollView.translatesAutoresizingMaskIntoConstraints = false
-				scrollView.heightAnchor.constraint(equalToConstant: 120).isActive = true
-
-				// Alternative solution
-//				scrollView.frame = CGRect(width: 300, height: 120)
-//				scrollView.onAddedToSuperview {
-//					if let messageTextField = (scrollView.superview?.superview?.subviews.first { $0 is NSTextField }) {
-//						scrollView.frame.width = messageTextField.frame.width
-//					} else {
-//						assertionFailure("Couldn't detect the message textfield view of the NSAlert panel")
-//					}
-//				}
+				scrollView.frame = CGRect(width: 300, height: 120)
 
 				scrollView.onAddedToSuperview {
 					if let messageTextField = (scrollView.superview?.superview?.subviews.first { $0 is NSTextField }) {
-						scrollView.bottomAnchor.constraint(equalTo: scrollView.superview!.bottomAnchor).isActive = true
-						scrollView.leftAnchor.constraint(equalTo: scrollView.superview!.leftAnchor).isActive = true
-						scrollView.widthAnchor.constraint(equalTo: messageTextField.widthAnchor).isActive = true
+						scrollView.frame.width = messageTextField.frame.width
+					} else {
+						assertionFailure("Couldn't detect the message textfield view of the NSAlert panel")
 					}
 				}
-
-				// FOR DEBUGGING
-				scrollView.drawsBackground = true
-				scrollView.backgroundColor = .red
-				//scrollView.frame = CGRect(width: 100, height: 100)
 
 				let textView = scrollView.documentView as! NSTextView
 				textView.drawsBackground = false
@@ -759,7 +742,7 @@ extension AVFormat: CustomStringConvertible {
 
 extension AVFormat: CustomDebugStringConvertible {
 	var debugDescription: String {
-		return "\(description) (\(fourCC))"
+		return "\(description) (\(fourCC.trimmingCharacters(in: .whitespaces)))"
 	}
 }
 

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -222,8 +222,8 @@ extension NSView {
 		}
 	}
 
-	// Enables you do add contraints and do other initialization without having to subclass the view.
 	// TODO: Please show me a better way to achieve this than using an invisible view 🙏
+	/// Enables you do add contraints and do other initialization without having to subclass the view.
 	func onAddedToSuperview(_ closure: @escaping () -> Void) {
 		let view = AddedToSuperviewObserverView()
 		view.onAdded = closure
@@ -266,6 +266,9 @@ extension NSAlert {
 		if let detailText = detailText {
 			if #available(macOS 10.14, *) {
 				let scrollView = NSTextView.scrollableTextView()
+
+				// We're setting the frame manually here as it's impossible to use auto-layout,
+				// since it has nothing to constrain to. This will eventually be rewritten in SwiftUI anyway.
 				scrollView.frame = CGRect(width: 300, height: 120)
 
 				scrollView.onAddedToSuperview {


### PR DESCRIPTION
Currently, it looks like this:

<img width="472" alt="Screen Shot 2019-05-17 at 18 42 13" src="https://user-images.githubusercontent.com/170270/57925825-c3cdfc80-78d3-11e9-808a-714774379a39.png">

But that's not very user-friendly.

I want it to look like this:

<img width="472" alt="Screen Shot 2019-05-17 at 18 46 11" src="https://user-images.githubusercontent.com/170270/57925938-11e30000-78d4-11e9-8052-c401e8b25b46.png">
