### PR TITLE
Show a notification when the conversion is completed

### DIFF
--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import AVFoundation
+import UserNotifications
 import StoreKit
 import Crashlytics
 
@@ -266,6 +267,14 @@ final class MainWindowController: NSWindowController {
 				defaults[.successfulConversionsCount] += 1
 				if #available(macOS 10.14, *), defaults[.successfulConversionsCount] == 5 {
 					SKStoreReviewController.requestReview()
+				}
+
+				if #available(macOS 10.14, *), !NSApp.isActive || self.window?.isVisible == false {
+					let notification = UNMutableNotificationContent()
+					notification.title = "Conversion Completed"
+					notification.subtitle = outputUrl.filename
+					let request = UNNotificationRequest(identifier: "conversionCompleted", content: notification, trigger: nil)
+					UNUserNotificationCenter.current().add(request)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #82

The notification will only be shown if the app isn't active or if the app is active but the window is not visible.

<img width="382" alt="Screen Shot 2019-06-22 at 02 07 25" src="https://user-images.githubusercontent.com/170270/59945800-e8992f00-9492-11e9-8a8e-54d490d86206.png">

// @sunshinejr