### PR TITLE
Improve the conversion completed view

### DIFF
--- a/Gifski/ConversionCompletedView.swift
+++ b/Gifski/ConversionCompletedView.swift
@@ -2,29 +2,38 @@ import Cocoa
 import Quartz
 
 final class ConversionCompletedView: SSView {
-	private let draggableFile = DraggableFile()
+	private let draggableFile = with(DraggableFile()) {
+		$0.translatesAutoresizingMaskIntoConstraints = false
+	}
 
 	private let fileNameLabel = with(Label()) {
-		$0.textColor = .secondaryLabelColor
-		$0.font = .boldSystemFont(ofSize: 14)
+		$0.translatesAutoresizingMaskIntoConstraints = false
+		$0.textColor = .labelColor
+		$0.font = NSFont.systemFont(ofSize: 14, weight: .semibold)
 		$0.alignment = .center
+		$0.maximumNumberOfLines = 1
+		$0.cell?.lineBreakMode = .byTruncatingTail
 	}
 
 	private let fileSizeLabel = with(Label()) {
+		$0.translatesAutoresizingMaskIntoConstraints = false
 		$0.textColor = .secondaryLabelColor
 		$0.font = .systemFont(ofSize: 12)
 		$0.alignment = .center
 	}
 
 	private let infoContainer = with(NSStackView()) {
+		$0.translatesAutoresizingMaskIntoConstraints = false
 		$0.orientation = .vertical
 	}
 
 	private let imageContainer = with(NSStackView()) {
+		$0.translatesAutoresizingMaskIntoConstraints = false
 		$0.orientation = .vertical
 	}
 
 	private let buttonsContainer = with(NSStackView()) {
+		$0.translatesAutoresizingMaskIntoConstraints = false
 		$0.orientation = .horizontal
 		$0.spacing = 20
 	}
@@ -33,18 +42,11 @@ final class ConversionCompletedView: SSView {
 		return isHidden == false && fileUrl != nil
 	}
 
-	private func createButton(title: String) -> CustomButton {
-		return with(CustomButton()) {
+	private func createButton(title: String) -> NSButton {
+		return with(NSButton()) {
+			$0.translatesAutoresizingMaskIntoConstraints = false
 			$0.title = title
-			$0.textColor = .themeColor
-			// TODO: Custombutton should have a better way of handling different color in dark and light mode
-			$0.activeTextColor = NSColor(named: "ButtonTextColor")!
-			$0.backgroundColor = .clear
-			$0.activeBackgroundColor = .themeColor
-			$0.borderColor = .themeColor
-			$0.activeBorderColor = .themeColor
-			$0.borderWidth = 1
-			$0.font = NSFont.systemFont(ofSize: 12, weight: .medium)
+			$0.bezelStyle = .texturedRounded
 		}
 	}
 
@@ -81,18 +83,6 @@ final class ConversionCompletedView: SSView {
 	override func didAppear() {
 		translatesAutoresizingMaskIntoConstraints = false
 
-		infoContainer.translatesAutoresizingMaskIntoConstraints = false
-		imageContainer.translatesAutoresizingMaskIntoConstraints = false
-		draggableFile.translatesAutoresizingMaskIntoConstraints = false
-		fileNameLabel.translatesAutoresizingMaskIntoConstraints = false
-		showInFinderButton.translatesAutoresizingMaskIntoConstraints = false
-		shareButton.translatesAutoresizingMaskIntoConstraints = false
-		fileSizeLabel.translatesAutoresizingMaskIntoConstraints = false
-		buttonsContainer.translatesAutoresizingMaskIntoConstraints = false
-
-		fileNameLabel.maximumNumberOfLines = 1
-		fileNameLabel.cell?.lineBreakMode = .byTruncatingTail
-
 		infoContainer.addArrangedSubview(fileNameLabel)
 		infoContainer.addArrangedSubview(fileSizeLabel)
 
@@ -115,10 +105,10 @@ final class ConversionCompletedView: SSView {
 			imageContainer.topAnchor.constraint(equalTo: topAnchor),
 			imageContainer.widthAnchor.constraint(equalTo: widthAnchor),
 
-			infoContainer.topAnchor.constraint(equalTo: draggableFile.bottomAnchor, constant: 16),
+			infoContainer.topAnchor.constraint(equalTo: draggableFile.bottomAnchor, constant: 18),
 			infoContainer.widthAnchor.constraint(equalTo: imageContainer.widthAnchor),
 
-			buttonsContainer.topAnchor.constraint(equalTo: imageContainer.bottomAnchor, constant: 24),
+			buttonsContainer.topAnchor.constraint(equalTo: infoContainer.bottomAnchor, constant: 24),
 			buttonsContainer.heightAnchor.constraint(equalToConstant: 30),
 			buttonsContainer.centerXAnchor.constraint(equalTo: centerXAnchor),
 


### PR DESCRIPTION
The main motivation for this is that the existing buttons are not very legible when the window is vibrant. I think it also looks better to just use the native buttons. I also did some cleanup.

#### Before

<img width="472" alt="Screen Shot 2019-06-22 at 14 36 51" src="https://user-images.githubusercontent.com/170270/59961016-87f20c80-94fb-11e9-991d-10e0ec67c628.png">


#### After

<img width="472" alt="Screen Shot 2019-06-22 at 14 38 27" src="https://user-images.githubusercontent.com/170270/59961019-8c1e2a00-94fb-11e9-9007-31008b68369f.png">
