### PR TITLE
Add Gifski metadata to the generated GIF

### DIFF
--- a/Gifski.xcodeproj/project.pbxproj
+++ b/Gifski.xcodeproj/project.pbxproj
@@ -82,7 +82,7 @@
 		6D86841621FD283B0044F6FE /* DraggableFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = DraggableFile.swift; sourceTree = "<group>"; usesTabs = 1; };
 		8548806422B78E8300E97401 /* IntTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = IntTextField.swift; sourceTree = "<group>"; usesTabs = 1; };
 		8548806D22B82D1300E97401 /* MenuPopUpButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MenuPopUpButton.swift; sourceTree = "<group>"; usesTabs = 1; };
-		858380E922BFD38B0086BC98 /* ExtendedAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedAttributes.swift; sourceTree = "<group>"; };
+		858380E922BFD38B0086BC98 /* ExtendedAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ExtendedAttributes.swift; sourceTree = "<group>"; usesTabs = 1; };
 		8588EB0C22A424B800030A59 /* ResizableDimensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ResizableDimensions.swift; sourceTree = "<group>"; usesTabs = 1; };
 		85B9CF6322BD3FA00050A2E4 /* Tooltip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Tooltip.swift; sourceTree = "<group>"; usesTabs = 1; };
 		9F3340A222431CC3006EF9B5 /* TimeRemainingEstimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = TimeRemainingEstimator.swift; sourceTree = "<group>"; usesTabs = 1; };

--- a/Gifski.xcodeproj/project.pbxproj
+++ b/Gifski.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		6D86841821FD283B0044F6FE /* DraggableFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D86841621FD283B0044F6FE /* DraggableFile.swift */; };
 		8548806522B78E8300E97401 /* IntTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8548806422B78E8300E97401 /* IntTextField.swift */; };
 		8548806E22B82D1400E97401 /* MenuPopUpButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8548806D22B82D1300E97401 /* MenuPopUpButton.swift */; };
+		858380EA22BFD38C0086BC98 /* ExtendedAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858380E922BFD38B0086BC98 /* ExtendedAttributes.swift */; };
 		8588EB0D22A424B800030A59 /* ResizableDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8588EB0C22A424B800030A59 /* ResizableDimensions.swift */; };
 		85B9CF6422BD3FA00050A2E4 /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B9CF6322BD3FA00050A2E4 /* Tooltip.swift */; };
 		9F3340A322431CC3006EF9B5 /* TimeRemainingEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3340A222431CC3006EF9B5 /* TimeRemainingEstimator.swift */; };
@@ -81,6 +82,7 @@
 		6D86841621FD283B0044F6FE /* DraggableFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = DraggableFile.swift; sourceTree = "<group>"; usesTabs = 1; };
 		8548806422B78E8300E97401 /* IntTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = IntTextField.swift; sourceTree = "<group>"; usesTabs = 1; };
 		8548806D22B82D1300E97401 /* MenuPopUpButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MenuPopUpButton.swift; sourceTree = "<group>"; usesTabs = 1; };
+		858380E922BFD38B0086BC98 /* ExtendedAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedAttributes.swift; sourceTree = "<group>"; };
 		8588EB0C22A424B800030A59 /* ResizableDimensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ResizableDimensions.swift; sourceTree = "<group>"; usesTabs = 1; };
 		85B9CF6322BD3FA00050A2E4 /* Tooltip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Tooltip.swift; sourceTree = "<group>"; usesTabs = 1; };
 		9F3340A222431CC3006EF9B5 /* TimeRemainingEstimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = TimeRemainingEstimator.swift; sourceTree = "<group>"; usesTabs = 1; };
@@ -209,6 +211,7 @@
 				8548806422B78E8300E97401 /* IntTextField.swift */,
 				8548806D22B82D1300E97401 /* MenuPopUpButton.swift */,
 				85B9CF6322BD3FA00050A2E4 /* Tooltip.swift */,
+				858380E922BFD38B0086BC98 /* ExtendedAttributes.swift */,
 				E3D08F6D1E5D7BFD00F465DF /* util.swift */,
 				E3AE628A1E5CD2F300035A2F /* MainMenu.xib */,
 				E3AE62881E5CD2F300035A2F /* Assets.xcassets */,
@@ -379,6 +382,7 @@
 				E3A6BD112245345C00F62256 /* Constants.swift in Sources */,
 				C2040B8920435871004EE259 /* GifskiWrapper.swift in Sources */,
 				8588EB0D22A424B800030A59 /* ResizableDimensions.swift in Sources */,
+				858380EA22BFD38C0086BC98 /* ExtendedAttributes.swift in Sources */,
 				E3CB1DD71F7E4CBC00D79BFC /* VideoDropView.swift in Sources */,
 				8548806522B78E8300E97401 /* IntTextField.swift in Sources */,
 				E3A940122182DCE5006981D5 /* CustomButton.swift in Sources */,

--- a/Gifski/ExtendedAttributes.swift
+++ b/Gifski/ExtendedAttributes.swift
@@ -1,0 +1,170 @@
+import AppKit
+
+extension POSIXError {
+	/// Create an error from the global C `errno`.
+	static var fromErrno: POSIXError {
+		return self.init(errno: errno)
+	}
+
+	/**
+	Create an error from the given C `errno`.
+
+	```
+	let length = getxattr(fileSystemPath, name, nil, 0, 0, 0)
+
+	guard length >= 0 else {
+	throw POSIXError(errno: errno)
+	}
+	```
+	*/
+	init(errno errorCode: Int32) {
+		self.init(POSIXErrorCode(rawValue: errorCode) ?? .EPERM)
+	}
+}
+
+
+final class ExtendedAttributes {
+	let url: URL
+
+	init(url: URL) {
+		self.url = url
+	}
+
+	private func checkIfFileURL() throws {
+		guard url.isFileURL else {
+			throw CocoaError(.fileNoSuchFile)
+		}
+	}
+
+	func has(_ name: String) -> Bool {
+		guard url.isFileURL else {
+			return false
+		}
+
+		return url.withUnsafeFileSystemRepresentation { fileSystemPath in
+			getxattr(fileSystemPath, name, nil, 0, 0, 0) > 0
+		}
+	}
+
+	func get(_ name: String) throws -> Data {
+		try checkIfFileURL()
+
+		return try url.withUnsafeFileSystemRepresentation { fileSystemPath in
+			let length = getxattr(fileSystemPath, name, nil, 0, 0, 0)
+
+			guard length >= 0 else {
+				throw POSIXError.fromErrno
+			}
+
+			var data = Data(count: length)
+
+			let result = data.withUnsafeMutableBytes {
+				getxattr(fileSystemPath, name, $0.baseAddress, length, 0, 0)
+			}
+
+			guard result >= 0 else {
+				throw POSIXError.fromErrno
+			}
+
+			return data
+		}
+	}
+
+	/**
+	- Note: Ensure you specify a type.
+
+	```
+	let isProtected: Bool = try? attributes.get("com.apple.rootless") ?? false
+	```
+	*/
+	func get<T>(_ name: String) throws -> T {
+		try checkIfFileURL()
+
+		let data = try get(name)
+
+		let value = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+
+		guard let result = value as? T else {
+			throw CocoaError(.propertyListReadCorrupt)
+		}
+
+		return result
+	}
+
+	func set(_ name: String, data: Data) throws {
+		try checkIfFileURL()
+
+		try url.withUnsafeFileSystemRepresentation { fileSystemPath in
+			let result = data.withUnsafeBytes {
+				setxattr(fileSystemPath, name, $0.baseAddress, data.count, 0, 0)
+			}
+
+			guard result >= 0 else {
+				throw POSIXError.fromErrno
+			}
+		}
+	}
+
+	func set<T>(_ name: String, value: T) throws {
+		try checkIfFileURL()
+
+		guard PropertyListSerialization.propertyList(value, isValidFor: .binary) else {
+			throw CocoaError(.propertyListWriteInvalid)
+		}
+
+		let data = try PropertyListSerialization.data(fromPropertyList: value, format: .binary, options: 0)
+		try set(name, data: data)
+	}
+
+	func remove(_ name: String) throws {
+		try checkIfFileURL()
+
+		try url.withUnsafeFileSystemRepresentation { fileSystemPath in
+			guard removexattr(fileSystemPath, name, 0) >= 0 else {
+				throw POSIXError.fromErrno
+			}
+		}
+	}
+
+	/// Get all the extended attribute names
+	func all() throws -> [String] {
+		try checkIfFileURL()
+
+		let list: [String] = try url.withUnsafeFileSystemRepresentation { fileSystemPath in
+			let length = listxattr(fileSystemPath, nil, 0, 0)
+
+			guard length >= 0 else {
+				throw POSIXError.fromErrno
+			}
+
+			var data = Data(count: length)
+
+			let result = data.withUnsafeMutableBytes {
+				listxattr(fileSystemPath, UnsafeMutablePointer<Int8>(OpaquePointer($0.baseAddress)), length, 0)
+			}
+
+			guard result >= 0 else {
+				throw POSIXError.fromErrno
+			}
+
+			let list = data.split(separator: 0).compactMap {
+				String(data: Data($0), encoding: .utf8)
+			}
+
+			return list
+		}
+
+		return list
+	}
+
+	func debug() {
+		print("Extended attributes:\n\(try! all().joined(separator: "\n"))")
+	}
+}
+
+
+extension URL {
+	var attributes: ExtendedAttributes {
+		return ExtendedAttributes(url: self)
+	}
+}

--- a/Gifski/ExtendedAttributes.swift
+++ b/Gifski/ExtendedAttributes.swift
@@ -13,7 +13,7 @@ extension POSIXError {
 	let length = getxattr(fileSystemPath, name, nil, 0, 0, 0)
 
 	guard length >= 0 else {
-	throw POSIXError(errno: errno)
+		throw POSIXError(errno: errno)
 	}
 	```
 	*/
@@ -126,7 +126,7 @@ final class ExtendedAttributes {
 		}
 	}
 
-	/// Get all the extended attribute names
+	/// Get all the extended attribute names.
 	func all() throws -> [String] {
 		try checkIfFileURL()
 

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -310,9 +310,7 @@ final class MainWindowController: NSWindowController {
 	}
 
 	private func addGifskiMetadata(to url: URL) {
-		let app = "\"\(App.name) \(App.versionWithBuild)\""
-		let itemCreatorKey = kMDItemCreator as String
-		setxattr(url.path, "com.apple.metadata:\(itemCreatorKey)", app, strlen(app), 0, 0)
+		try? url.setMetadata(key: .itemCreator, value: "\(App.name) \(App.versionWithBuild)")
 	}
 }
 

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -258,7 +258,7 @@ final class MainWindowController: NSWindowController {
 					self.presentError(error, modalFor: self.window)
 				}
 
-				try? inputUrl.setMetadata(key: .itemCreator, value: "\(App.name) \(App.versionWithBuild)")
+				try? outputUrl.setMetadata(key: .itemCreator, value: "\(App.name) \(App.versionWithBuild)")
 				self.progress?.unpublish()
 				self.isRunning = false
 

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -258,7 +258,7 @@ final class MainWindowController: NSWindowController {
 					self.presentError(error, modalFor: self.window)
 				}
 
-				self.addGifskiMetadata(to: outputUrl)
+				try? url.setMetadata(key: .itemCreator, value: "\(App.name) \(App.versionWithBuild)")
 				self.progress?.unpublish()
 				self.isRunning = false
 
@@ -307,10 +307,6 @@ final class MainWindowController: NSWindowController {
 			timeRemainingLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 			timeRemainingLabel.topAnchor.constraint(equalTo: circularProgress.bottomAnchor)
 		])
-	}
-
-	private func addGifskiMetadata(to url: URL) {
-		try? url.setMetadata(key: .itemCreator, value: "\(App.name) \(App.versionWithBuild)")
 	}
 }
 

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -258,7 +258,7 @@ final class MainWindowController: NSWindowController {
 					self.presentError(error, modalFor: self.window)
 				}
 
-				try? outputUrl.setMetadata(key: .itemCreator, value: "\(App.name) \(App.versionWithBuild)")
+				try? outputUrl.setMetadata(key: .itemCreator, value: "\(App.name) \(App.version)")
 				self.progress?.unpublish()
 				self.isRunning = false
 

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -258,6 +258,7 @@ final class MainWindowController: NSWindowController {
 					self.presentError(error, modalFor: self.window)
 				}
 
+				self.addGifskiMetadata(to: outputUrl)
 				self.progress?.unpublish()
 				self.isRunning = false
 
@@ -306,6 +307,12 @@ final class MainWindowController: NSWindowController {
 			timeRemainingLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 			timeRemainingLabel.topAnchor.constraint(equalTo: circularProgress.bottomAnchor)
 		])
+	}
+
+	private func addGifskiMetadata(to url: URL) {
+		let app = "\"\(App.name) \(App.versionWithBuild)\""
+		let itemCreatorKey = kMDItemCreator as String
+		setxattr(url.path, "com.apple.metadata:\(itemCreatorKey)", app, strlen(app), 0, 0)
 	}
 }
 

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -258,7 +258,7 @@ final class MainWindowController: NSWindowController {
 					self.presentError(error, modalFor: self.window)
 				}
 
-				try? url.setMetadata(key: .itemCreator, value: "\(App.name) \(App.versionWithBuild)")
+				try? inputUrl.setMetadata(key: .itemCreator, value: "\(App.name) \(App.versionWithBuild)")
 				self.progress?.unpublish()
 				self.isRunning = false
 

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2386,7 +2386,7 @@ extension NSControl {
 
 extension URL {
 	enum MetadataKey {
-		/// The app used to create the file, for example, "Word", "QuickTime", etc.
+		/// The app used to create the file, for example, `Gifski 2.0.0`, `QuickTime Player 10.5`, etc.
 		case itemCreator
 
 		var attributeKey: String {

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2398,7 +2398,6 @@ extension URL {
 	}
 
 	func setMetadata<T>(key: MetadataKey, value: T) throws {
-		let attributes = ExtendedAttributes(url: self)
 		try attributes.set("com.apple.metadata:\(key.attributeKey)", value: value)
 	}
 }

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2386,6 +2386,7 @@ extension NSControl {
 
 extension URL {
 	enum MetadataKey {
+		/// The app used to create the file, for example, "Word", "QuickTime", etc.
 		case itemCreator
 
 		var attributeKey: String {

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2383,3 +2383,21 @@ extension NSControl {
 		window?.makeFirstResponder(self)
 	}
 }
+
+extension URL {
+	enum MetadataKey {
+		case itemCreator
+
+		var attributeKey: String {
+			switch self {
+			case .itemCreator:
+				return kMDItemCreator as String
+			}
+		}
+	}
+
+	func setMetadata<T>(key: MetadataKey, value: T) throws {
+		let attributes = ExtendedAttributes(url: self)
+		try attributes.set("com.apple.metadata:\(key.attributeKey)", value: value)
+	}
+}


### PR DESCRIPTION
Fixes #61.

So this is not exactly using the IPTC properties mentioned in the issue but one of the common metadata properties from [Apple's docs](https://developer.apple.com/documentation/coreservices/file_metadata/mditem/common_metadata_attribute_keys).

The reason is that GIF doesn't seem to support IPTC properties in the GIF itself, and when I tried to set these as extended attributes they weren't properly recognized as "real" IPTC properties (used `exiftool`/`mdls` for the check). But I found a nice extended attribute that macOS is also displaying on the sidebar in Finder (don't mind the polish language 😄):

<img width="446" alt="Zrzut ekranu 2019-06-23 o 02 09 28" src="https://user-images.githubusercontent.com/5232779/59975164-402fbb80-95b5-11e9-866e-24c40ff73518.png">

Let me know @sindresorhus @kornelski what do you think about it!

---
**Edit:** Also, there is an API for `MDItem` that could **fetch attributes** but for some reason there is no exposed function to **set attributes**. But, in fact, there is a runtime function for saving these properties and if we expose it in our objc header in Gifski with:
```objective-c
@import CoreServices;

Boolean MDItemSetAttribute(MDItemRef, CFStringRef name, CFTypeRef attr);
```
we have a "nice-looking" API to set these properties instead of using `setxattr`:
```swift
if let item = MDItemCreate(nil, url.path as CFString) {
	MDItemSetAttribute(item, kMDItemCreator, "Gifski 1.8.0 (17)" as CFTypeRef)
}
```
It also seems to be there forever but not sure how safe this is 😄


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#61: Add metadata?](https://issuehunt.io/repos/119822304/issues/61)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->