### PR TITLE
Fix Quick Look when window is inactive on completion

### DIFF
--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -29,6 +29,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		if urlToConvertOnLaunch != nil {
 			mainWindowController.convert(urlToConvertOnLaunch)
 		}
+
+		mainWindowController.window?.printResponderChainOnChanges()
 	}
 
 	func application(_ application: NSApplication, open urls: [URL]) {
@@ -57,6 +59,111 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	func application(_ application: NSApplication, willPresentError error: Error) -> Error {
 		Crashlytics.recordNonFatalError(error: error)
 		return error
+	}
+}
+
+extension NSResponder {
+	/// Get the responder chain as a sequence.
+	var nextResponderChain: AnySequence<NSResponder> {
+		var currentNextResponder = nextResponder
+
+		return AnySequence(AnyIterator<NSResponder> {
+			defer {
+				currentNextResponder = currentNextResponder?.nextResponder
+			}
+
+			return currentNextResponder
+		})
+	}
+}
+
+extension NSWindow {
+	func printResponderChain() {
+		print("Responder chain:")
+
+		print("(Main view controller: \(contentViewController)")
+
+		guard let firstResponder = self.firstResponder else {
+			print("  - None")
+			return
+		}
+
+		print("  - \(firstResponder)")
+
+		for responder in firstResponder.nextResponderChain {
+			print("  - \(responder)")
+		}
+	}
+
+	func printResponderChainOnChanges() {
+		printResponderChain()
+
+		observe(\.firstResponder) { window, _  in
+			window.printResponderChain()
+		}.tiedToLifetimeOf(self)
+	}
+
+	// TODO: Write a similar thing for `NSApplication` that fllows windows by observing `keyWindow`.
+}
+
+
+
+enum AssociationPolicy {
+	case assign
+	case retainNonatomic
+	case copyNonatomic
+	case retain
+	case copy
+
+	fileprivate var rawValue: objc_AssociationPolicy {
+		switch self {
+		case .assign:
+			return .OBJC_ASSOCIATION_ASSIGN
+		case .retainNonatomic:
+			return .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+		case .copyNonatomic:
+			return .OBJC_ASSOCIATION_COPY_NONATOMIC
+		case .retain:
+			return .OBJC_ASSOCIATION_RETAIN
+		case .copy:
+			return .OBJC_ASSOCIATION_COPY
+		}
+	}
+}
+
+final class ObjectAssociation<T: Any> {
+	private let policy: AssociationPolicy
+
+	init(policy: AssociationPolicy = .retainNonatomic) {
+		self.policy = policy
+	}
+
+	subscript(index: Any) -> T? {
+		get {
+			return objc_getAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque()) as! T?
+		} set {
+			objc_setAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque(), newValue, policy.rawValue)
+		}
+	}
+}
+
+private let bindLifetimeAssociatedObjectKey = ObjectAssociation<[AnyObject]>()
+
+// TODO: This needs to hold `target` weakly. Right now it introduces a memory leak, as `of` will also keep `target` alive.
+/// Binds the lifetime of object A to object B, so when B deallocates, so does A, but not before.
+func bindLifetime(of object: AnyObject, to target: AnyObject) {
+	var retainedObjects = bindLifetimeAssociatedObjectKey[target] ?? []
+	retainedObjects.append(object)
+	bindLifetimeAssociatedObjectKey[target] = retainedObjects
+}
+
+extension NSKeyValueObservation {
+	// Note to self: I like this pattern of composability.
+	/// Keeps the observation alive as long as the given object.
+	@discardableResult
+	func tiedToLifetimeOf(_ object: AnyObject) -> NSKeyValueObservation {
+		bindLifetime(of: self, to: object)
+		return self
 	}
 }
 

--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -41,8 +41,8 @@ final class ConversionCompletedViewController: NSViewController {
 	override func viewDidAppear() {
 		super.viewDidAppear()
 
+		// This is needed for Quick Look to work.
 		self.view.window?.makeFirstResponder(self)
-		self.view.window?.printResponderChain()
 
 		if #available(macOS 10.14, *), defaults[.successfulConversionsCount] == 5 {
 			SKStoreReviewController.requestReview()

--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -41,6 +41,9 @@ final class ConversionCompletedViewController: NSViewController {
 	override func viewDidAppear() {
 		super.viewDidAppear()
 
+		self.view.window?.makeFirstResponder(self)
+		self.view.window?.printResponderChain()
+
 		if #available(macOS 10.14, *), defaults[.successfulConversionsCount] == 5 {
 			SKStoreReviewController.requestReview()
 		}

--- a/Gifski/ConversionViewController.swift
+++ b/Gifski/ConversionViewController.swift
@@ -42,14 +42,20 @@ final class ConversionViewController: NSViewController {
 		view = wrapper
 	}
 
-	override func viewDidLoad() {
-		super.viewDidLoad()
+	override func viewDidAppear() {
+		super.viewDidAppear()
+
+		view.window?.makeFirstResponder(self)
 
 		start(conversion: conversion)
 	}
 
 	/// Gets called when the Esc key is pressed.
-	/// Reference: https://stackoverflow.com/a/42440020
+	override func cancelOperation(_ sender: Any?) {
+		cancelConversion()
+	}
+
+	// TODO: Remove this when we target macOS 10.14.
 	@objc
 	func cancel(_ sender: Any?) {
 		cancelConversion()

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2449,7 +2449,6 @@ extension NSViewController {
 		}, completionHandler: {
 			window.contentViewController = viewController
 			viewController.view.animator().alphaValue = 1.0
-			window.makeFirstResponder(viewController)
 			completion?()
 		})
 	}


### PR DESCRIPTION
Fixes #100

---

With focus:

```
...
Responder chain:
(Main view controller: Optional(<Gifski.ConversionViewController: 0x600003b02220>)
  - <Gifski.ConversionViewController: 0x600003b02220>
  - <NSWindow: 0x600003e11300>
  - <Gifski.MainWindowController: 0x600002109ef0>
Responder chain:
(Main view controller: Optional(<Gifski.ConversionCompletedViewController: 0x10212bcf0>)
  - <Gifski.ConversionCompletedViewController: 0x10212bcf0>
  - <NSWindow: 0x600003e11300>
  - <Gifski.MainWindowController: 0x600002109ef0>
```

Without focus:

```
...
Responder chain:
(Main view controller: Optional(<Gifski.ConversionViewController: 0x600003b06680>)
  - <Gifski.ConversionViewController: 0x600003b06680>
  - <NSWindow: 0x600003e02600>
  - <Gifski.MainWindowController: 0x60000212d180>
```

Notice how the `ConversionCompletedViewController` never becomes first responder when the window is not active.

---

I'm gonna remove the debug utilities before merging.