### PR TITLE
Ensure the trim range is valid

### DIFF
--- a/Gifski/TrimmingAVPlayerViewController.swift
+++ b/Gifski/TrimmingAVPlayerViewController.swift
@@ -57,11 +57,11 @@ final class TrimmingAVPlayerView: AVPlayerView {
 		// Once we change minimum target to 10.15,
 		// observe `\.duration` instead of `\.forwardPlaybackEndTime`.
 		timeRangeObserver = player?.currentItem?.observe(\.forwardPlaybackEndTime, options: .new) { item, _ in
-			let startTime = item.reversePlaybackEndTime.seconds
-			let endTime = item.forwardPlaybackEndTime.seconds
-			if !startTime.isNaN && !endTime.isNaN {
-				updateClosure(startTime...endTime)
+			guard let playbackRange = item.playbackRange else {
+				return
 			}
+
+			updateClosure(playbackRange)
 		}
 	}
 

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2515,3 +2515,18 @@ extension NSObject {
 		return type(of: self).simpleClassName
 	}
 }
+
+extension AVPlayerItem {
+	/// The playable range of the item.
+	/// Can be `nil` when the `.duration` is not available, for example, when the asset has not yet been fully loaded or if it's a live stream.
+	var playbackRange: ClosedRange<Double>? {
+		guard duration.isNumeric else {
+			return nil
+		}
+
+		let startTime = reversePlaybackEndTime.isNumeric ? reversePlaybackEndTime.seconds : 0
+		let endTime = forwardPlaybackEndTime.isNumeric ? forwardPlaybackEndTime.seconds : duration.seconds
+
+		return startTime < endTime ? startTime...endTime : endTime...startTime
+	}
+}


### PR DESCRIPTION
This hopefully fixes a crash report we received in Crashlytics:

```
TrimmingAVPlayerViewController.swift line 63
closure #1 in TrimmingAVPlayerView.observeTrimmedTimeRange(_:) + 63
```