### PR TITLE
Properly overwrite an existing file in "Save As…"

### DIFF
--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -125,7 +125,7 @@ final class ConversionCompletedViewController: NSViewController {
 				}
 
 				do {
-					try FileManager.default.copyItem(at: url, to: outputUrl)
+					try FileManager.default.copyItem(at: url, to: outputUrl, overwrite: true)
 				} catch {
 					self.presentError(error)
 				}

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2530,3 +2530,14 @@ extension AVPlayerItem {
 		return startTime < endTime ? startTime...endTime : endTime...startTime
 	}
 }
+
+extension FileManager {
+	/// Copy a file and optionally overwrite the destination if it exists.
+	func copyItem(at sourceURL: URL, to destinationURL: URL, overwrite: Bool = false) throws {
+		if overwrite {
+			try? FileManager.default.removeItem(at: destinationURL)
+		}
+
+		try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+	}
+}


### PR DESCRIPTION
It's safe as the user has already chosen it in the save panel.

This fixes https://fabric.io/sindre-sorhus-projects/mac/apps/com.sindresorhus.gifski/issues/8d68af97f6950bbab08700019b64be60/sessions/latest?build=109799998 (Only visible for maintainers)