### PR TITLE
Ensure the trimmed duration is at least 0.1 seconds

### DIFF
--- a/Gifski/TrimmingAVPlayerViewController.swift
+++ b/Gifski/TrimmingAVPlayerViewController.swift
@@ -70,7 +70,7 @@ final class TrimmingAVPlayerView: AVPlayerView {
 		// observe `\.duration` instead of `\.forwardPlaybackEndTime`.
 		timeRangeObserver = player?.currentItem?.observe(\.forwardPlaybackEndTime, options: .new) { item, _ in
 			guard
-				let fullRange = item.range,
+				let fullRange = item.durationRange,
 				let playbackRange = item.playbackRange
 			else {
 				return
@@ -79,13 +79,13 @@ final class TrimmingAVPlayerView: AVPlayerView {
 			/// Prevent infinite recursion.
 			guard !skipNextUpdate else {
 				skipNextUpdate = false
-				updateClosure(playbackRange.minimumRangeDiff(of: self.minimumTrimDuration, in: fullRange))
+				updateClosure(playbackRange.minimumRangeLength(of: self.minimumTrimDuration, in: fullRange))
 				return
 			}
 
-			guard playbackRange.interval > self.minimumTrimDuration else {
+			guard playbackRange.length > self.minimumTrimDuration else {
 				skipNextUpdate = true
-				item.playbackRange = playbackRange.minimumRangeDiff(of: self.minimumTrimDuration, in: fullRange)
+				item.playbackRange = playbackRange.minimumRangeLength(of: self.minimumTrimDuration, in: fullRange)
 				return
 			}
 

--- a/Gifski/TrimmingAVPlayerViewController.swift
+++ b/Gifski/TrimmingAVPlayerViewController.swift
@@ -12,6 +12,13 @@ final class TrimmingAVPlayerViewController: NSViewController {
 	private let controlsStyle: AVPlayerViewControlsStyle
 	private let timeRangeDidChange: ((ClosedRange<Double>) -> Void)?
 
+	/// The minimum duration the trimmer can be set to.
+	var minimumTrimDuration = 0.1 {
+		didSet {
+			playerView.minimumTrimDuration = minimumTrimDuration
+		}
+	}
+
 	init(
 		asset: AVURLAsset,
 		controlsStyle: AVPlayerViewControlsStyle = .inline,
@@ -52,12 +59,33 @@ final class TrimmingAVPlayerView: AVPlayerView {
 	private var timeRangeObserver: NSKeyValueObservation?
 	private var trimmingObserver: NSKeyValueObservation?
 
+	/// The minimum duration the trimmer can be set to.
+	var minimumTrimDuration = 0.1
+
 	fileprivate func observeTrimmedTimeRange(_ updateClosure: @escaping (ClosedRange<Double>) -> Void) {
+		var skipNextUpdate = false
+
 		// Observing `.duration` seems buggy on macOS 10.14.
 		// Once we change minimum target to 10.15,
 		// observe `\.duration` instead of `\.forwardPlaybackEndTime`.
 		timeRangeObserver = player?.currentItem?.observe(\.forwardPlaybackEndTime, options: .new) { item, _ in
-			guard let playbackRange = item.playbackRange else {
+			guard
+				let fullRange = item.range,
+				let playbackRange = item.playbackRange
+			else {
+				return
+			}
+
+			/// Prevent infinite recursion.
+			guard !skipNextUpdate else {
+				skipNextUpdate = false
+				updateClosure(playbackRange.minimumRangeDiff(of: self.minimumTrimDuration, in: fullRange))
+				return
+			}
+
+			guard playbackRange.interval > self.minimumTrimDuration else {
+				skipNextUpdate = true
+				item.playbackRange = playbackRange.minimumRangeDiff(of: self.minimumTrimDuration, in: fullRange)
 				return
 			}
 

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2626,6 +2626,10 @@ extension ClosedRange where Bound == Double {
 	```
 	*/
 	func minimumRangeLength(of length: Bound, in fullRange: ClosedRange<Bound>) -> ClosedRange<Bound> {
+		guard length > self.length else {
+			return self
+		}
+
 		assert(isSubset(of: fullRange), "`self` must be a subset of the given range")
 		assert(lowerBound >= 0 && upperBound >= 0, "`self` must the positive")
 		assert(fullRange.lowerBound >= 0 && fullRange.upperBound >= 0, "The given range must be positive")


### PR DESCRIPTION
Currently, it's possible to trim to zero seconds. We should not allow that. This PR makes the trim handles expand to the minimum trim interval if it's too small.