### PR TITLE
Fix tooltip crash

### DIFF
--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -61,7 +61,11 @@ final class ConversionCompletedViewController: NSViewController {
 			wrapperView.fadeIn(duration: 0.5, delay: 0.15, completion: nil)
 		}
 
-		delay(seconds: 1) {
+		delay(seconds: 1) { [weak self] in
+			guard let self = self else {
+				return
+			}
+
 			self.tooltip.show(from: self.draggableFile, preferredEdge: .maxY)
 		}
 	}

--- a/Gifski/Tooltip.swift
+++ b/Gifski/Tooltip.swift
@@ -40,6 +40,11 @@ final class Tooltip: NSPopover {
 		of positioningView: NSView,
 		preferredEdge: NSRectEdge
 	) {
+		guard positioningView.window != nil else {
+			assertionFailure("Tooltip must be shown from a view with a window")
+			return
+		}
+
 		if !showOnlyOnce || (showOnlyOnce && defaults[showKey] < 1) {
 			defaults[showKey] += 1
 			super.show(relativeTo: positioningRect, of: positioningView, preferredEdge: preferredEdge)


### PR DESCRIPTION
This fixes a crash that could happen if a user quickly drags in a file right after the conversion completed view is presented, before the tooltip has been shown.

Fixes https://fabric.io/sindre-sorhus-projects/mac/apps/com.sindresorhus.gifski/issues/fbbde1a1afc20492a9eb6961bcedbc1e?time=last-thirty-days (Only accessible by maintainers)