### PR TITLE
Prevent a crash when the data is released to early

### DIFF
--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -179,7 +179,7 @@ final class Gifski {
 					if result.isFinished {
 						do {
 							try gifski.finish()
-							// Force unwrapping here is safe because we nil gifData in one single after this.
+							// Force unwrapping here is safe because we nil gifData in one single place after this.
 							completionHandlerOnce(.success(gifData! as Data))
 						} catch {
 							completionHandlerOnce(.failure(.writeFailed(error)))

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -44,6 +44,7 @@ final class Gifski {
 		}
 	}
 
+	// This is carefully nil'd and remain private.
 	private static var gifData: NSMutableData?
 
 	// TODO: Split this method up into smaller methods. It's too large.
@@ -56,7 +57,7 @@ final class Gifski {
 		var progress = Progress(parent: .current())
 
 		let completionHandlerOnce = Once().wrap { (_ result: Result<Data, Error>) -> Void in
-			gifData = nil
+			gifData = nil // resetting state here
 			DispatchQueue.main.async {
 				guard !progress.isCancelled else {
 					completionHandler?(.failure(.cancelled))
@@ -177,6 +178,7 @@ final class Gifski {
 					if result.isFinished {
 						do {
 							try gifski.finish()
+							// Force unwrapping here is safe because we nil gifData in one single place in this file.
 							completionHandlerOnce(.success(gifData! as Data))
 						} catch {
 							completionHandlerOnce(.failure(.writeFailed(error)))

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -44,7 +44,7 @@ final class Gifski {
 		}
 	}
 
-	// This is carefully nil'd and remain private.
+	// This is carefully nil'd and should remain private.
 	private static var gifData: NSMutableData?
 
 	// TODO: Split this method up into smaller methods. It's too large.

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -57,7 +57,8 @@ final class Gifski {
 		var progress = Progress(parent: .current())
 
 		let completionHandlerOnce = Once().wrap { (_ result: Result<Data, Error>) -> Void in
-			gifData = nil // resetting state here
+			gifData = nil // Resetting state
+
 			DispatchQueue.main.async {
 				guard !progress.isCancelled else {
 					completionHandler?(.failure(.cancelled))
@@ -178,7 +179,7 @@ final class Gifski {
 					if result.isFinished {
 						do {
 							try gifski.finish()
-							// Force unwrapping here is safe because we nil gifData in one single place in this file.
+							// Force unwrapping here is safe because we nil gifData in one single after this.
 							completionHandlerOnce(.success(gifData! as Data))
 						} catch {
 							completionHandlerOnce(.failure(.writeFailed(error)))

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -44,6 +44,8 @@ final class Gifski {
 		}
 	}
 
+	private static var gifData: NSMutableData?
+
 	// TODO: Split this method up into smaller methods. It's too large.
 	/**
 	Converts a movie to GIF
@@ -54,6 +56,7 @@ final class Gifski {
 		var progress = Progress(parent: .current())
 
 		let completionHandlerOnce = Once().wrap { (_ result: Result<Data, Error>) -> Void in
+			gifData = nil
 			DispatchQueue.main.async {
 				guard !progress.isCancelled else {
 					completionHandler?(.failure(.cancelled))
@@ -83,7 +86,7 @@ final class Gifski {
 			return progress.isCancelled ? 0 : 1
 		}
 
-		var gifData = NSMutableData()
+		gifData = NSMutableData()
 
 		gifski.setWriteCallback(context: &gifData) { bufferLength, bufferPointer, context in
 			guard
@@ -174,7 +177,7 @@ final class Gifski {
 					if result.isFinished {
 						do {
 							try gifski.finish()
-							completionHandlerOnce(.success(gifData as Data))
+							completionHandlerOnce(.success(gifData! as Data))
 						} catch {
 							completionHandlerOnce(.failure(.writeFailed(error)))
 						}


### PR DESCRIPTION
Increase retain count so not released too early. 

Closes #118 