### PR TITLE
Confirm quitting the app during conversion

### DIFF
--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -52,6 +52,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
 
+	func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+		if mainWindowController.isConverting {
+			let response = NSAlert.showModal(
+				for: mainWindowController.window,
+				message: "Do you want to continue converting?",
+				informativeText: "Gifski is currently converting your video. If you quit, the conversion will be cancelled.",
+				buttonTitles: [
+					"Continue",
+					"Quit"
+				]
+			)
+
+			if response == .alertFirstButtonReturn {
+				return .terminateCancel
+			}
+		}
+
+		return .terminateNow
+	}
+
 	func application(_ application: NSApplication, willPresentError error: Error) -> Error {
 		Crashlytics.recordNonFatalError(error: error)
 		return error

--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -57,7 +57,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 			let response = NSAlert.showModal(
 				for: mainWindowController.window,
 				message: "Do you want to continue converting?",
-				informativeText: "Gifski is currently converting your video. If you quit, the conversion will be cancelled.",
+				informativeText: "Gifski is currently converting a video. If you quit, the conversion will be cancelled.",
 				buttonTitles: [
 					"Continue",
 					"Quit"

--- a/Gifski/Vendor/CircularProgress+Util.swift
+++ b/Gifski/Vendor/CircularProgress+Util.swift
@@ -214,3 +214,14 @@ extension CABasicAnimation {
 		return animation
 	}
 }
+
+
+extension NSWindow {
+	/// Whether the window or its owning app is showing a modal or sheet.
+	/// This can be useful to disable any unintended interaction underneath it,
+	/// for example, drag and drop or mouse hover.
+	var isShowingModalOrSheet: Bool {
+		NSApp.modalWindow != nil ||
+		attachedSheet != nil
+	}
+}

--- a/Gifski/Vendor/CircularProgress.swift
+++ b/Gifski/Vendor/CircularProgress.swift
@@ -370,7 +370,15 @@ public final class CircularProgress: NSView {
 	}
 
 	override public func mouseEntered(with event: NSEvent) {
-		guard isCancellable && !isCancelled && !isFinished else {
+		guard window?.isShowingModalOrSheet != true else {
+			return
+		}
+
+		guard
+			isCancellable,
+			!isCancelled,
+			!isFinished
+		else {
 			super.mouseEntered(with: event)
 			return
 		}

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -252,13 +252,15 @@ extension NSAlert {
 		message: String,
 		informativeText: String? = nil,
 		detailText: String? = nil,
-		style: NSAlert.Style = .warning
+		style: NSAlert.Style = .warning,
+		buttonTitles: [String] = []
 	) -> NSApplication.ModalResponse {
 		NSAlert(
 			message: message,
 			informativeText: informativeText,
 			detailText: detailText,
-			style: style
+			style: style,
+			buttonTitles: buttonTitles
 		).runModal(for: window)
 	}
 
@@ -266,7 +268,8 @@ extension NSAlert {
 		message: String,
 		informativeText: String? = nil,
 		detailText: String? = nil,
-		style: NSAlert.Style = .warning
+		style: NSAlert.Style = .warning,
+		buttonTitles: [String] = []
 	) {
 		self.init()
 		self.messageText = message
@@ -304,6 +307,8 @@ extension NSAlert {
 				self.informativeText += "\n\(detailText)"
 			}
 		}
+
+		self.addButtons(withTitles: buttonTitles)
 	}
 
 	/// Runs the alert as a window-modal sheet, or as an app-modal (window-indepedendent) alert if the window is `nil` or not given.
@@ -318,6 +323,13 @@ extension NSAlert {
 		}
 
 		return NSApp.runModal(for: window)
+	}
+
+	/// Adds buttons with the given titles to the alert.
+	func addButtons(withTitles buttonTitles: [String]) {
+		for buttonTitle in buttonTitles {
+			addButton(withTitle: buttonTitle)
+		}
 	}
 }
 


### PR DESCRIPTION
To prevent people accidentally quitting.

<img width="426" alt="Screenshot 2019-09-14 at 16 07 02" src="https://user-images.githubusercontent.com/170270/64905989-578cc980-d70a-11e9-9493-48f35dbcc7ed.png">

The conversion continues behind it.

The wording is taken from the Photos app when exporting:

![image](https://user-images.githubusercontent.com/170270/64905992-6d01f380-d70a-11e9-988b-29565b025a07.png)
