### PR TITLE
Use custom presentation animator

### DIFF
--- a/Gifski.xcodeproj/project.pbxproj
+++ b/Gifski.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B576D25422294F9900A9B75C /* CircularProgress+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = B576D24F22294F9900A9B75C /* CircularProgress+Util.swift */; };
 		C2040B8920435871004EE259 /* GifskiWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2040B8820435871004EE259 /* GifskiWrapper.swift */; };
 		C2AFA91D204FFEFD00FC5A7F /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AFA91B204FFEFD00FC5A7F /* MainWindowController.swift */; };
+		D9CA6EB42348AF7500B5DC15 /* ReplacePresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CA6EB32348AF7500B5DC15 /* ReplacePresentationAnimator.swift */; };
 		E3030388233785C100B8ED1F /* CustomButton+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3030387233785C100B8ED1F /* CustomButton+Util.swift */; };
 		E30557F0207E521F003401A1 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30557EF207E521F003401A1 /* Defaults.swift */; };
 		E317FF132057E24700A80A18 /* CircularProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E317FF122057E24700A80A18 /* CircularProgress.swift */; };
@@ -98,6 +99,7 @@
 		B576D24F22294F9900A9B75C /* CircularProgress+Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "CircularProgress+Util.swift"; sourceTree = "<group>"; usesTabs = 1; };
 		C2040B8820435871004EE259 /* GifskiWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = GifskiWrapper.swift; sourceTree = "<group>"; usesTabs = 1; };
 		C2AFA91B204FFEFD00FC5A7F /* MainWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MainWindowController.swift; sourceTree = "<group>"; usesTabs = 1; };
+		D9CA6EB32348AF7500B5DC15 /* ReplacePresentationAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacePresentationAnimator.swift; sourceTree = "<group>"; };
 		E3030387233785C100B8ED1F /* CustomButton+Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "CustomButton+Util.swift"; sourceTree = "<group>"; usesTabs = 1; };
 		E30557EF207E521F003401A1 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		E317FF122057E24700A80A18 /* CircularProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgress.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 				85B9CF6322BD3FA00050A2E4 /* Tooltip.swift */,
 				858380E922BFD38B0086BC98 /* ExtendedAttributes.swift */,
 				85A5C44722CA41B500CAA94D /* VideoValidator.swift */,
+				D9CA6EB32348AF7500B5DC15 /* ReplacePresentationAnimator.swift */,
 				E3D08F6D1E5D7BFD00F465DF /* util.swift */,
 				E3AE628A1E5CD2F300035A2F /* MainMenu.xib */,
 				E3AE62881E5CD2F300035A2F /* Assets.xcassets */,
@@ -389,6 +392,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E30557F0207E521F003401A1 /* Defaults.swift in Sources */,
+				D9CA6EB42348AF7500B5DC15 /* ReplacePresentationAnimator.swift in Sources */,
 				E317FF1C20583E9800A80A18 /* DockProgress.swift in Sources */,
 				E317FF132057E24700A80A18 /* CircularProgress.swift in Sources */,
 				85B9CF6422BD3FA00050A2E4 /* Tooltip.swift in Sources */,

--- a/Gifski/ConversionViewController.swift
+++ b/Gifski/ConversionViewController.swift
@@ -113,14 +113,14 @@ final class ConversionViewController: NSViewController {
 
 		let videoDropController = VideoDropViewController()
 		stopConversion { [weak self] in
-			self?.push(viewController: videoDropController)
+			self?.present(videoDropController, animator: ReplacePresentationAnimator())
 		}
 	}
 
 	private func didComplete(conversion: Gifski.Conversion, gifUrl: URL) {
 		let conversionCompleted = ConversionCompletedViewController(conversion: conversion, gifUrl: gifUrl)
 		stopConversion { [weak self] in
-			self?.push(viewController: conversionCompleted)
+			self?.present(conversionCompleted, animator: ReplacePresentationAnimator())
 		}
 	}
 

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -69,12 +69,12 @@ final class EditVideoViewController: NSViewController {
 		)
 
 		let convert = ConversionViewController(conversion: conversion)
-		push(viewController: convert)
+		present(convert, animator: ReplacePresentationAnimator())
 	}
 
 	@IBAction private func cancel(_ sender: Any) {
 		let videoDropController = VideoDropViewController()
-		push(viewController: videoDropController)
+		present(videoDropController, animator: ReplacePresentationAnimator())
 	}
 
 	override func viewDidLoad() {

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -61,7 +61,7 @@ final class MainWindowController: NSWindowController {
 		}
 
 		let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
-		window?.contentViewController?.push(viewController: editController)
+		window?.contentViewController?.present(editController, animator: ReplacePresentationAnimator())
 	}
 }
 

--- a/Gifski/ReplacePresentationAnimator.swift
+++ b/Gifski/ReplacePresentationAnimator.swift
@@ -1,0 +1,39 @@
+//
+//  ReplacePresentationAnimator.swift
+//  Gifski
+//
+//  Created by Sergey Kuryanov on 05/10/2019.
+//  Copyright © 2019 Sindre Sorhus. All rights reserved.
+//
+
+import Cocoa
+
+class ReplacePresentationAnimator: NSObject, NSViewControllerPresentationAnimator {
+	func animatePresentation(of viewController: NSViewController, from fromViewController: NSViewController) {
+		animateTransition(of: viewController, from: fromViewController)
+	}
+
+	func animateDismissal(of viewController: NSViewController, from fromViewController: NSViewController) {
+		animateTransition(of: viewController, from: fromViewController)
+	}
+
+	private func animateTransition(of viewController: NSViewController, from fromViewController: NSViewController) {
+		guard let window = fromViewController.view.window else {
+			return
+		}
+
+		var newWindowFrame = CGRect(origin: .zero, size: viewController.view.frame.size)
+		newWindowFrame.center = window.frame.center
+
+		viewController.view.alphaValue = 0
+
+		NSAnimationContext.runAnimationGroup({ _ in
+			fromViewController.view.animator().alphaValue = 0
+			window.contentViewController = nil
+			window.animator().setFrame(newWindowFrame, display: true)
+		}, completionHandler: {
+			window.contentViewController = viewController
+			viewController.view.animator().alphaValue = 1
+		})
+	}
+}

--- a/Gifski/VideoDropViewController.swift
+++ b/Gifski/VideoDropViewController.swift
@@ -31,6 +31,6 @@ final class VideoDropViewController: NSViewController {
 		}
 
 		let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
-		push(viewController: editController)
+		present(editController, animator: ReplacePresentationAnimator())
 	}
 }

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2348,26 +2348,6 @@ extension URL {
 }
 
 extension NSViewController {
-	func push(viewController: NSViewController, completion: (() -> Void)? = nil) {
-		guard let window = view.window else {
-			return
-		}
-
-		let newOrigin = CGPoint(x: window.frame.midX - viewController.view.frame.width / 2.0, y: window.frame.midY - viewController.view.frame.height / 2.0)
-		let newWindowFrame = CGRect(origin: newOrigin, size: viewController.view.frame.size)
-
-		viewController.view.alphaValue = 0.0
-		NSAnimationContext.runAnimationGroup({ _ in
-			window.contentViewController?.view.animator().alphaValue = 0.0
-			window.contentViewController = nil
-			window.animator().setFrame(newWindowFrame, display: true)
-		}, completionHandler: {
-			window.contentViewController = viewController
-			viewController.view.animator().alphaValue = 1.0
-			completion?()
-		})
-	}
-
 	func add(childController: NSViewController) {
 		add(childController: childController, to: view)
 	}


### PR DESCRIPTION
This PR is attempt to Fixes #108 

Custom animator was added and used.

Unfortunately app crashes when you try to `dismiss` controller presented with `present(_, animator:). I assume this is because `window.contentViewController` being replaced.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#108: Use `NSViewController.present()` with custom animator](https://issuehunt.io/repos/119822304/issues/108)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->