### PR TITLE
Add checkerboard background for the trim view

### DIFF
--- a/Gifski.xcodeproj/project.pbxproj
+++ b/Gifski.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B576D25422294F9900A9B75C /* CircularProgress+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = B576D24F22294F9900A9B75C /* CircularProgress+Util.swift */; };
 		C2040B8920435871004EE259 /* GifskiWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2040B8820435871004EE259 /* GifskiWrapper.swift */; };
 		C2AFA91D204FFEFD00FC5A7F /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AFA91B204FFEFD00FC5A7F /* MainWindowController.swift */; };
+		D957BCDE234941C200A9A9F9 /* CheckerboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D957BCDD234941C200A9A9F9 /* CheckerboardView.swift */; };
 		E3030388233785C100B8ED1F /* CustomButton+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3030387233785C100B8ED1F /* CustomButton+Util.swift */; };
 		E30557F0207E521F003401A1 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30557EF207E521F003401A1 /* Defaults.swift */; };
 		E317FF132057E24700A80A18 /* CircularProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E317FF122057E24700A80A18 /* CircularProgress.swift */; };
@@ -98,6 +99,7 @@
 		B576D24F22294F9900A9B75C /* CircularProgress+Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "CircularProgress+Util.swift"; sourceTree = "<group>"; usesTabs = 1; };
 		C2040B8820435871004EE259 /* GifskiWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = GifskiWrapper.swift; sourceTree = "<group>"; usesTabs = 1; };
 		C2AFA91B204FFEFD00FC5A7F /* MainWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MainWindowController.swift; sourceTree = "<group>"; usesTabs = 1; };
+		D957BCDD234941C200A9A9F9 /* CheckerboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckerboardView.swift; sourceTree = "<group>"; };
 		E3030387233785C100B8ED1F /* CustomButton+Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "CustomButton+Util.swift"; sourceTree = "<group>"; usesTabs = 1; };
 		E30557EF207E521F003401A1 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		E317FF122057E24700A80A18 /* CircularProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgress.swift; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				6D86841121FD283B0044F6FE /* ConversionCompletedViewController.swift */,
 				E3FEF31422C52819003AEFED /* ConversionCompletedViewController.xib */,
 				85BF910822F3279300AD3FF6 /* TrimmingAVPlayerViewController.swift */,
+				D957BCDD234941C200A9A9F9 /* CheckerboardView.swift */,
 				E3CB1DD61F7E4CBC00D79BFC /* VideoDropView.swift */,
 				6D86841621FD283B0044F6FE /* DraggableFile.swift */,
 				9F3340A222431CC3006EF9B5 /* TimeRemainingEstimator.swift */,
@@ -397,6 +400,7 @@
 				E3A6BD112245345C00F62256 /* Constants.swift in Sources */,
 				C2040B8920435871004EE259 /* GifskiWrapper.swift in Sources */,
 				8588EB0D22A424B800030A59 /* ResizableDimensions.swift in Sources */,
+				D957BCDE234941C200A9A9F9 /* CheckerboardView.swift in Sources */,
 				858380EA22BFD38C0086BC98 /* ExtendedAttributes.swift in Sources */,
 				E3030388233785C100B8ED1F /* CustomButton+Util.swift in Sources */,
 				E3CB1DD71F7E4CBC00D79BFC /* VideoDropView.swift in Sources */,

--- a/Gifski/Assets.xcassets/CheckerboardFirstColor.colorset/Contents.json
+++ b/Gifski/Assets.xcassets/CheckerboardFirstColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.261",
+          "alpha" : "1.000",
+          "blue" : "0.261",
+          "green" : "0.261"
+        }
+      }
+    }
+  ]
+}

--- a/Gifski/Assets.xcassets/CheckerboardSecondColor.colorset/Contents.json
+++ b/Gifski/Assets.xcassets/CheckerboardSecondColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "209",
+          "alpha" : "1.000",
+          "blue" : "209",
+          "green" : "209"
+        }
+      }
+    }
+  ]
+}

--- a/Gifski/Assets.xcassets/CheckerboardSecondColor.colorset/Contents.json
+++ b/Gifski/Assets.xcassets/CheckerboardSecondColor.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "209"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x83",
+          "alpha" : "1.000",
+          "blue" : "0x85",
+          "green" : "0x84"
+        }
+      }
     }
   ]
 }

--- a/Gifski/CheckerboardView.swift
+++ b/Gifski/CheckerboardView.swift
@@ -1,0 +1,48 @@
+//
+//  CheckerboardView.swift
+//  Gifski
+//
+//  Created by Sergey Kuryanov on 06/10/2019.
+//  Copyright © 2019 Sindre Sorhus. All rights reserved.
+//
+
+import Cocoa
+
+class CheckerboardView: NSView {
+	let gridSize = CGSize(width: 10, height: 10)
+	let firstColor = NSColor.white
+	let secondColor = NSColor.lightGray
+
+	let clearRect: CGRect
+
+	init(frame: NSRect, clearRect: CGRect) {
+		self.clearRect = clearRect
+
+		super.init(frame: frame)
+	}
+
+	required init?(coder: NSCoder) {
+		self.clearRect = .zero
+
+		super.init(coder: coder)
+	}
+
+	override func draw(_ dirtyRect: NSRect) {
+		super.draw(dirtyRect)
+
+		firstColor.setFill()
+		dirtyRect.fill()
+
+		secondColor.setFill()
+
+		for y in 0...Int(bounds.size.height / gridSize.height) {
+			for x in 0...Int(bounds.size.width / gridSize.width) where x % 2 == y % 2 {
+				let origin = CGPoint(x: x * Int(gridSize.width), y: y * Int(gridSize.height))
+				let rect = CGRect(origin: origin, size: gridSize)
+				rect.fill()
+			}
+		}
+
+		clearRect.fill(using: .clear)
+	}
+}

--- a/Gifski/CheckerboardView.swift
+++ b/Gifski/CheckerboardView.swift
@@ -35,7 +35,7 @@ final class CheckerboardView: NSView {
 		secondColor.setFill()
 
 		for y in 0...Int(bounds.size.height / gridSize.height) {
-			for x in 0...Int(bounds.size.width / gridSize.width) where x % 2 == y % 2 {
+			for x in 0...Int(bounds.size.width / gridSize.width) where x.isEven == y.isEven {
 				let origin = CGPoint(x: x * Int(gridSize.width), y: y * Int(gridSize.height))
 				let rect = CGRect(origin: origin, size: gridSize)
 				rect.fill()

--- a/Gifski/CheckerboardView.swift
+++ b/Gifski/CheckerboardView.swift
@@ -10,8 +10,6 @@ import Cocoa
 
 final class CheckerboardView: NSView {
 	private let gridSize = CGSize(width: 10, height: 10)
-	private let firstColor = NSColor.white
-	private let secondColor = NSColor.lightGray
 	private let clearRect: CGRect
 
 	init(frame: CGRect, clearRect: CGRect) {
@@ -29,10 +27,10 @@ final class CheckerboardView: NSView {
 	override func draw(_ dirtyRect: CGRect) {
 		super.draw(dirtyRect)
 
-		firstColor.setFill()
+		NSColor.Checkerboard.first.setFill()
 		dirtyRect.fill()
 
-		secondColor.setFill()
+		NSColor.Checkerboard.second.setFill()
 
 		for y in 0...Int(bounds.size.height / gridSize.height) {
 			for x in 0...Int(bounds.size.width / gridSize.width) where x.isEven == y.isEven {

--- a/Gifski/CheckerboardView.swift
+++ b/Gifski/CheckerboardView.swift
@@ -9,7 +9,7 @@
 import Cocoa
 
 final class CheckerboardView: NSView {
-	private let gridSize = CGSize(width: 10, height: 10)
+	private let gridSize = CGSize(width: 8, height: 8)
 	private let clearRect: CGRect
 
 	init(frame: CGRect, clearRect: CGRect) {

--- a/Gifski/CheckerboardView.swift
+++ b/Gifski/CheckerboardView.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class CheckerboardView: NSView {
+final class CheckerboardView: NSView {
 	private let gridSize = CGSize(width: 10, height: 10)
 	private let firstColor = NSColor.white
 	private let secondColor = NSColor.lightGray

--- a/Gifski/CheckerboardView.swift
+++ b/Gifski/CheckerboardView.swift
@@ -9,13 +9,12 @@
 import Cocoa
 
 class CheckerboardView: NSView {
-	let gridSize = CGSize(width: 10, height: 10)
-	let firstColor = NSColor.white
-	let secondColor = NSColor.lightGray
+	private let gridSize = CGSize(width: 10, height: 10)
+	private let firstColor = NSColor.white
+	private let secondColor = NSColor.lightGray
+	private let clearRect: CGRect
 
-	let clearRect: CGRect
-
-	init(frame: NSRect, clearRect: CGRect) {
+	init(frame: CGRect, clearRect: CGRect) {
 		self.clearRect = clearRect
 
 		super.init(frame: frame)
@@ -27,7 +26,7 @@ class CheckerboardView: NSView {
 		super.init(coder: coder)
 	}
 
-	override func draw(_ dirtyRect: NSRect) {
+	override func draw(_ dirtyRect: CGRect) {
 		super.draw(dirtyRect)
 
 		firstColor.setFill()

--- a/Gifski/Constants.swift
+++ b/Gifski/Constants.swift
@@ -2,6 +2,11 @@ import Cocoa
 
 extension NSColor {
 	static let themeColor = NSColor.controlAccentColorPolyfill
+
+	enum Checkerboard {
+		static let first = NSColor(named: "CheckerboardFirstColor")!
+		static let second = NSColor(named: "CheckerboardSecondColor")!
+	}
 }
 
 extension Defaults.Keys {

--- a/Gifski/TrimmingAVPlayerViewController.swift
+++ b/Gifski/TrimmingAVPlayerViewController.swift
@@ -44,6 +44,7 @@ final class TrimmingAVPlayerViewController: NSViewController {
 	override func viewDidAppear() {
 		super.viewDidAppear()
 
+		playerView.addCheckerboardView()
 		playerView.hideTrimButtons()
 		playerView.observeTrimmedTimeRange { [weak self] timeRange in
 			self?.timeRange = timeRange
@@ -130,5 +131,10 @@ final class TrimmingAVPlayerView: AVPlayerView {
 			.subviews
 			.filter { ($0 as? NSButton)?.image == nil }
 			.forEach { $0.isHidden = true }
+	}
+
+	fileprivate func addCheckerboardView() {
+		let overlayView = CheckerboardView(frame: frame, clearRect: videoBounds)
+		contentOverlayView?.addSubview(overlayView)
 	}
 }

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2574,3 +2574,8 @@ extension ClosedRange where Bound == Double {
 		return self
 	}
 }
+
+extension BinaryInteger {
+	var isEven: Bool { isMultiple(of: 2) }
+	var isOdd: Bool { !isEven }
+}

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -69,14 +69,6 @@ extension NSColor {
 	}
 }
 
-// MARK: - Checkerboard Colors
-extension NSColor {
-	enum Checkerboard {
-		static let first = NSColor(named: "CheckerboardFirstColor") ?? NSColor.white
-		static let second = NSColor(named: "CheckerboardSecondColor") ?? NSColor.lightGray
-	}
-}
-
 
 extension NSView {
 	func shake(duration: TimeInterval = 0.3, direction: NSUserInterfaceLayoutOrientation) {

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -69,6 +69,14 @@ extension NSColor {
 	}
 }
 
+// MARK: - Checkerboard Colors
+extension NSColor {
+	enum Checkerboard {
+		static let first = NSColor(named: "CheckerboardFirstColor") ?? NSColor.white
+		static let second = NSColor(named: "CheckerboardSecondColor") ?? NSColor.lightGray
+	}
+}
+
 
 extension NSView {
 	func shake(duration: TimeInterval = 0.3, direction: NSUserInterfaceLayoutOrientation) {


### PR DESCRIPTION
Fixes #113

Seems like background color of `AVPlayerView` can't be modified, but we can use a trick.
We can add overlay with with a window for video preview. This makes effect of checkerboard background.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#113: Replace black background on trimming view with a checkerboard NSColor](https://issuehunt.io/repos/119822304/issues/113)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->