### PR TITLE
Fix CircularProgress crash

### DIFF
--- a/Gifski.xcodeproj/xcshareddata/xcschemes/Gifski.xcscheme
+++ b/Gifski.xcodeproj/xcshareddata/xcschemes/Gifski.xcscheme
@@ -59,8 +59,6 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      stopOnEveryThreadSanitizerIssue = "YES"
-      stopOnEveryMainThreadCheckerIssue = "YES"
       migratedStopOnEveryIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">

--- a/Gifski/Vendor/CircularProgress+Util.swift
+++ b/Gifski/Vendor/CircularProgress+Util.swift
@@ -225,3 +225,12 @@ extension NSWindow {
 		attachedSheet != nil
 	}
 }
+
+
+func assertMainThread(
+	function: StaticString = #function,
+	file: String = #file,
+	line: UInt = #line
+) {
+	assert(Thread.isMainThread, "\(function) in \(file.nsString.lastPathComponent):\(line) must run on the main thread!")
+}

--- a/Gifski/Vendor/CircularProgress.swift
+++ b/Gifski/Vendor/CircularProgress.swift
@@ -82,7 +82,6 @@ public final class CircularProgress: NSView {
 	The progress value in the range `0...1`.
 
 	- Note: The value will be clamped to `0...1`.
-	- Note: Can be set from a background thread.
 	*/
 	@IBInspectable public var progress: Double {
 		get {
@@ -132,12 +131,12 @@ public final class CircularProgress: NSView {
 			_isFinished = newValue
 
 			if _isFinished {
-				self.isIndeterminate = false
+				isIndeterminate = false
 
-				if !self.isCancelled, self.showCheckmarkAtHundredPercent {
-					self.progressLabel.string = ""
-					self.cancelButton.isHidden = true
-					self.successView.isHidden = false
+				if !isCancelled, showCheckmarkAtHundredPercent {
+					progressLabel.string = ""
+					cancelButton.isHidden = true
+					successView.isHidden = false
 				}
 			}
 		}
@@ -439,10 +438,10 @@ public final class CircularProgress: NSView {
 			_isIndeterminate = newValue
 			didChangeValue(for: \.isIndeterminate)
 
-			if self._isIndeterminate {
-				self.startIndeterminateState()
+			if _isIndeterminate {
+				startIndeterminateState()
 			} else {
-				self.stopIndeterminateState()
+				stopIndeterminateState()
 			}
 		}
 	}

--- a/Gifski/Vendor/CircularProgress.swift
+++ b/Gifski/Vendor/CircularProgress.swift
@@ -61,8 +61,12 @@ public final class CircularProgress: NSView {
 	Defaults to the user's accent color. For High Sierra and below it uses a fallback color.
 	*/
 	@IBInspectable public var color: NSColor {
-		get { _color }
+		get {
+			assertMainThread()
+			return _color
+		}
 		set {
+			assertMainThread()
 			_color = newValue
 			originalColor = newValue
 			needsDisplay = true
@@ -81,8 +85,13 @@ public final class CircularProgress: NSView {
 	- Note: Can be set from a background thread.
 	*/
 	@IBInspectable public var progress: Double {
-		get { _progress }
+		get {
+			assertMainThread()
+			return _progress
+		}
 		set {
+			assertMainThread()
+
 			_progress = newValue.clamped(to: 0...1)
 
 			// swiftlint:disable:next trailing_closure
@@ -90,9 +99,7 @@ public final class CircularProgress: NSView {
 				self.progressCircle.progress = self._progress
 			})
 
-			DispatchQueue.main.async {
-				self.progressLabel.isHidden = self.progress == 0 && self.isIndeterminate ? self.cancelButton.isHidden : !self.cancelButton.isHidden
-			}
+			progressLabel.isHidden = progress == 0 && isIndeterminate ? cancelButton.isHidden : !cancelButton.isHidden
 
 			if !progressLabel.isHidden {
 				progressLabel.string = "\(Int(_progress * 100))%"
@@ -102,9 +109,6 @@ public final class CircularProgress: NSView {
 			if _progress == 1 {
 				isFinished = true
 			}
-
-			// TODO: Figure out why I need to flush here to get the label to update in `Gifski.app`.
-			CATransaction.flush()
 		}
 	}
 
@@ -114,6 +118,8 @@ public final class CircularProgress: NSView {
 	*/
 	@IBInspectable public private(set) var isFinished: Bool {
 		get {
+			assertMainThread()
+
 			if let progressInstance = progressInstance {
 				return progressInstance.isFinished
 			}
@@ -121,21 +127,17 @@ public final class CircularProgress: NSView {
 			return _isFinished
 		}
 		set {
+			assertMainThread()
+
 			_isFinished = newValue
 
 			if _isFinished {
-				DispatchQueue.main.async { [weak self] in
-					guard let self = self else {
-						return
-					}
+				self.isIndeterminate = false
 
-					self.isIndeterminate = false
-
-					if !self.isCancelled, self.showCheckmarkAtHundredPercent {
-						self.progressLabel.string = ""
-						self.cancelButton.isHidden = true
-						self.successView.isHidden = false
-					}
+				if !self.isCancelled, self.showCheckmarkAtHundredPercent {
+					self.progressLabel.string = ""
+					self.cancelButton.isHidden = true
+					self.successView.isHidden = false
 				}
 			}
 		}
@@ -146,33 +148,42 @@ public final class CircularProgress: NSView {
 	*/
 	public var progressInstance: Progress? {
 		didSet {
+			assertMainThread()
+
 			if let progressInstance = progressInstance {
 				progressObserver = progressInstance.observe(\.fractionCompleted) { sender, _ in
-					guard !self.isCancelled && !sender.isFinished else {
-						return
-					}
+					DispatchQueue.main.async {
+						guard !self.isCancelled && !sender.isFinished else {
+							return
+						}
 
-					self.progress = sender.fractionCompleted
+						self.progress = sender.fractionCompleted
+					}
 				}
 
 				finishedObserver = progressInstance.observe(\.isFinished) { sender, _ in
-					guard !self.isCancelled && sender.isFinished else {
-						return
-					}
+					DispatchQueue.main.async {
+						guard !self.isCancelled && sender.isFinished else {
+							return
+						}
 
-					self.progress = 1
+						self.progress = 1
+					}
 				}
 
 				cancelledObserver = progressInstance.observe(\.isCancelled) { sender, _ in
-					self.isCancelled = sender.isCancelled
+					DispatchQueue.main.async {
+						self.isCancelled = sender.isCancelled
+					}
 				}
 
 				indeterminateObserver = progressInstance.observe(\.isIndeterminate) { sender, _ in
-					self.isIndeterminate = sender.isIndeterminate
+					DispatchQueue.main.async {
+						self.isIndeterminate = sender.isIndeterminate
+					}
 				}
 
 				isCancellable = progressInstance.isCancellable
-
 				isIndeterminate = progressInstance.isIndeterminate
 			}
 		}
@@ -243,6 +254,8 @@ public final class CircularProgress: NSView {
 	Reset the progress back to zero without animating.
 	*/
 	public func resetProgress() {
+		assertMainThread()
+
 		alphaValue = 1
 
 		_color = originalColor
@@ -264,6 +277,8 @@ public final class CircularProgress: NSView {
 	Cancels `Progress` if it's set and prevents further updates.
 	*/
 	public func cancelProgress() {
+		assertMainThread()
+
 		guard isCancellable else {
 			return
 		}
@@ -287,6 +302,8 @@ public final class CircularProgress: NSView {
 	*/
 	@IBInspectable public var isCancellable: Bool {
 		get {
+			assertMainThread()
+
 			if let progressInstance = progressInstance {
 				return progressInstance.isCancellable
 			}
@@ -294,6 +311,8 @@ public final class CircularProgress: NSView {
 			return _isCancellable
 		}
 		set {
+			assertMainThread()
+
 			_isCancellable = newValue
 			updateTrackingAreas()
 		}
@@ -305,6 +324,8 @@ public final class CircularProgress: NSView {
 	*/
 	@IBInspectable public private(set) var isCancelled: Bool {
 		get {
+			assertMainThread()
+
 			if let progressInstance = progressInstance {
 				return progressInstance.isCancelled
 			}
@@ -312,6 +333,8 @@ public final class CircularProgress: NSView {
 			return _isCancelled
 		}
 		set {
+			assertMainThread()
+
 			_isCancelled = newValue
 
 			if newValue {
@@ -410,20 +433,16 @@ public final class CircularProgress: NSView {
 			return _isIndeterminate
 		}
 		set {
+			assertMainThread()
+
 			willChangeValue(for: \.isIndeterminate)
 			_isIndeterminate = newValue
 			didChangeValue(for: \.isIndeterminate)
 
-			DispatchQueue.main.async { [weak self] in
-				guard let self = self else {
-					return
-				}
-
-				if self._isIndeterminate {
-					self.startIndeterminateState()
-				} else {
-					self.stopIndeterminateState()
-				}
+			if self._isIndeterminate {
+				self.startIndeterminateState()
+			} else {
+				self.stopIndeterminateState()
 			}
 		}
 	}

--- a/Gifski/Vendor/CircularProgress.swift
+++ b/Gifski/Vendor/CircularProgress.swift
@@ -124,13 +124,16 @@ public final class CircularProgress: NSView {
 			_isFinished = newValue
 
 			if _isFinished {
-				isIndeterminate = false
+				DispatchQueue.main.async { [weak self] in
+					guard let self = self else {
+						return
+					}
 
-				if !isCancelled, showCheckmarkAtHundredPercent {
-					progressLabel.string = ""
-					cancelButton.isHidden = true
+					self.isIndeterminate = false
 
-					DispatchQueue.main.async {
+					if !self.isCancelled, self.showCheckmarkAtHundredPercent {
+						self.progressLabel.string = ""
+						self.cancelButton.isHidden = true
 						self.successView.isHidden = false
 					}
 				}
@@ -411,10 +414,16 @@ public final class CircularProgress: NSView {
 			_isIndeterminate = newValue
 			didChangeValue(for: \.isIndeterminate)
 
-			if _isIndeterminate {
-				startIndeterminateState()
-			} else {
-				stopIndeterminateState()
+			DispatchQueue.main.async { [weak self] in
+				guard let self = self else {
+					return
+				}
+
+				if self._isIndeterminate {
+					self.startIndeterminateState()
+				} else {
+					self.stopIndeterminateState()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
There has been 21 crashes in v2.1.0 for this:

```
Fatal Exception: NSInternalInconsistencyException
NSWindow drag regions should only be invalidated on the Main Thread!
6  Gifski                         0x1068d8325 CircularProgress.isFinished.setter (<compiler-generated>)
7  Gifski                         0x1068d7de0 CircularProgress.progress.setter + 107 (CircularProgress.swift:107)
8  Gifski                         0x1068d8a50 closure #2 in CircularProgress.progressInstance.didset + 161 (CircularProgress.swift:161)
9  Gifski                         0x10691b24f thunk for @escaping @callee_guaranteed (@guaranteed NSProgress, @in_guaranteed NSKeyValueObservedChange<Bool>) -> () (<compiler-generated>)
10 libswiftFoundation.dylib       0x7fff72311bb6 $s10Foundation27_KeyValueCodingAndObservingPAAE7observe_7options13changeHandlerAA05NSKeyC11ObservationCs0B4PathCyxqd__G_So0kcF7OptionsVyx_AA0kC14ObservedChangeVyqd__GtctlFySo8NSObjectC_AOyypGtcfU_
11 libswiftFoundation.dylib       0x7fff723a2fb9 $s10Foundation27_KeyValueCodingAndObservingPAAE7observe_7options13changeHandlerAA05NSKeyC11ObservationCs0B4PathCyxqd__G_So0kcF7OptionsVyx_AA0kC14ObservedChangeVyqd__GtctlFySo8NSObjectC_AOyypGtcfU_TA
12 libswiftFoundation.dylib       0x7fff723a2e17 $s10Foundation21NSKeyValueObservationC019_swizzle_me_observeC010forKeyPath2of6change7contextySSSg_ypSgSDySo8NSStringCypGSgSvSgtFTf4dnndn_n
13 libswiftFoundation.dylib       0x7fff72311316 $s10Foundation21NSKeyValueObservationC019_swizzle_me_observeC010forKeyPath2of6change7contextySSSg_ypSgSDySo8NSStringCypGSgSvSgtFTo
14 Foundation                     0x7fff48a2ff08 NSKeyValueNotifyObserver
15 Foundation                     0x7fff48a2f984 NSKeyValueDidChange
16 Foundation                     0x7fff48bb9ead NSKeyValueDidChangeWithPerThreadPendingNotifications.llvm.7538459074364299148
17 CoreFoundation                 0x7fff4681b867 (Missing)
18 Foundation                     0x7fff48a8e12a -[NSProgress _setValueForKeys:settingBlock:]
19 Foundation                     0x7fff48b05a14 (Missing)
20 Foundation                     0x7fff48a8f75a (Missing)
21 Gifski                         0x1068f6e87 @objc closure #2 in static Gifski.run(_:completionHandler:) + 93 (Gifski.swift:93)
22 Gifski                         0x106924a5d _$LT$gifski..progress..ProgressCallback$u20$as$u20$gifski..progress..ProgressReporter$GT$::increase::h38ffd2e7bb6b7e57
23 Gifski                         0x106931aa0 gifski::Writer::write::haa6ec2bf93d87d93
24 Gifski                         0x106929bd1 gifski::c_api::gifski_write_sync_internal::hd59452488b4436f5
25 Gifski                         0x106939337 std::sys_common::backtrace::__rust_begin_short_backtrace::hf426f0f1bb683314
26 Gifski                         0x10692aa5c std::panicking::try::do_call::hfa9c1991c45d90cf (.llvm.8325536553258157362)
27 Gifski                         0x1069c088c __rust_maybe_catch_panic + 31 (lib.rs:31)
28 Gifski                         0x10692d160 core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h0e110dce52ed5d44
29 Gifski                         0x10699489e _$LT$alloc..boxed..Box$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$A$GT$$GT$::call_once::ha44ca87baccc45af + 220 (alloc.rs:220)
30 Gifski                         0x1069bf97e std::sys::unix::thread::Thread::new::thread_start::hceb9fd3b79bf176c + 104 (alloc.rs:104)
```

Seems the macOS 10.15 SDK got stricter. I have not been able to reproduce this though. So this is just a shot in the dark. I'm just making sure anything UI related is done on the main process.