### PR TITLE
Work around crash caused by Crashlytics swizzling

### DIFF
--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import UserNotifications
 import Fabric
 import Crashlytics
 
@@ -8,6 +9,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	var hasFinishedLaunching = false
 	var urlToConvertOnLaunch: URL!
 
+	// Possible workaround for crashing bug because of Crashlytics swizzling.
+	var notificationCenter: AnyObject? = {
+		if #available(macOS 10.14, *) {
+			return UNUserNotificationCenter.current()
+		} else {
+			return nil
+		}
+	}()
+
 	func applicationWillFinishLaunching(_ notification: Notification) {
 		UserDefaults.standard.register(defaults: [
 			"NSApplicationCrashOnExceptions": true,
@@ -16,6 +26,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
+		if #available(macOS 10.14, *) {
+			(notificationCenter as? UNUserNotificationCenter)?.requestAuthorization { _, _ in }
+		}
+
 		#if !DEBUG
 			Fabric.with([Crashlytics.self])
 		#endif

--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -36,6 +36,15 @@ final class ConversionCompletedViewController: NSViewController {
 		setUpUI()
 		setUpDropView()
 		setUp(url: gifUrl)
+
+		if #available(macOS 10.14, *), !NSApp.isActive || view.window?.isVisible == false {
+			let notification = UNMutableNotificationContent()
+			notification.title = "Conversion Completed"
+			notification.subtitle = conversion.video.filename
+			let request = UNNotificationRequest(identifier: "conversionCompleted", content: notification, trigger: nil)
+			// UNUserNotificationCenter.current().add(request)
+			(AppDelegate.shared.notificationCenter as? UNUserNotificationCenter)?.add(request)
+		}
 	}
 
 	override func viewDidAppear() {
@@ -43,18 +52,6 @@ final class ConversionCompletedViewController: NSViewController {
 
 		// This is needed for Quick Look to work.
 		view.window?.makeFirstResponder(self)
-
-		if #available(macOS 10.14, *), Defaults[.successfulConversionsCount] == 5 {
-			SKStoreReviewController.requestReview()
-		}
-
-		if #available(macOS 10.14, *), !NSApp.isActive || view.window?.isVisible == false {
-			let notification = UNMutableNotificationContent()
-			notification.title = "Conversion Completed"
-			notification.subtitle = conversion.video.filename
-			let request = UNNotificationRequest(identifier: "conversionCompleted", content: notification, trigger: nil)
-			UNUserNotificationCenter.current().add(request)
-		}
 
 		if wrapperView.isHidden {
 			draggableFile.layer?.animateScaleMove(fromScale: 3, fromY: view.frame.height + draggableFile.frame.size.height)
@@ -67,6 +64,10 @@ final class ConversionCompletedViewController: NSViewController {
 			}
 
 			self.tooltip.show(from: self.draggableFile, preferredEdge: .maxY)
+		}
+
+		if #available(macOS 10.14, *), Defaults[.successfulConversionsCount] == 5 {
+			SKStoreReviewController.requestReview()
 		}
 	}
 

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2579,3 +2579,7 @@ extension BinaryInteger {
 	var isEven: Bool { isMultiple(of: 2) }
 	var isOdd: Bool { !isEven }
 }
+
+extension AppDelegate {
+	static var shared: AppDelegate { NSApp.delegate as! AppDelegate }
+}


### PR DESCRIPTION
See: https://github.com/firebase/firebase-ios-sdk/issues/195 The workaround creates a reference to the notification center before Crashlytics swizzles it.

Hopefully, we can move to MS AppCenter soon. We just need https://github.com/microsoft/appcenter/issues/192 first.

Also new in Catalina:
- `viewDidAppear` is not called until the window is made visible by the user if the app is hidden or the window is minimized when the view is loaded.
- You have to call `requestAuthorization` even if you don't need alert-type notification or user interaction, which is not made explicit by the docs:
	> Request authorization to interact with the user through alerts, sounds, and icon badges. (Authorization is required for all user interactions.)
	
	(Makes it sound like it's not needed for us, and it did work in Mojave without...)