### PR TITLE
Add option for non-looping output

### DIFF
--- a/Gifski/Constants.swift
+++ b/Gifski/Constants.swift
@@ -12,6 +12,7 @@ extension NSColor {
 extension Defaults.Keys {
 	static let outputQuality = Key<Double>("outputQuality", default: 1)
 	static let successfulConversionsCount = Key<Int>("successfulConversionsCount", default: 0)
+	static let singleIteration = Key<Bool>("singleIteration", default: false)
 }
 
 struct Constants {

--- a/Gifski/EditVideoViewController.xib
+++ b/Gifski/EditVideoViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15400" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15400"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,6 +14,7 @@
                 <outlet property="frameRateLabel" destination="5Ke-gz-J2u" id="VaC-Et-vm7"/>
                 <outlet property="frameRateSlider" destination="Rej-Dl-z8Y" id="cIA-dv-KJw"/>
                 <outlet property="heightTextField" destination="bzf-LM-SxO" id="67N-9X-vzq"/>
+                <outlet property="loopButton" destination="Mk2-3o-6CT" id="lFW-e9-tIT"/>
                 <outlet property="playerViewWrapper" destination="64m-0V-WWu" id="6cd-p2-aMe"/>
                 <outlet property="predefinedSizesDropdown" destination="BWw-q9-45K" id="mLx-BM-G3f"/>
                 <outlet property="qualitySlider" destination="wmm-UU-g6g" id="RlB-Ty-dIN"/>
@@ -49,16 +50,16 @@
                     </view>
                 </box>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="dmb-Gl-vWp">
-                    <rect key="frame" x="24" y="41" width="757" height="123"/>
+                    <rect key="frame" x="24" y="43" width="757" height="121"/>
                     <subviews>
                         <box titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="EGL-as-iA7">
-                            <rect key="frame" x="-3" y="-4" width="391" height="129"/>
+                            <rect key="frame" x="-3" y="-4" width="391" height="127"/>
                             <view key="contentView" id="0XA-H7-N8J">
-                                <rect key="frame" x="3" y="3" width="385" height="123"/>
+                                <rect key="frame" x="3" y="3" width="385" height="121"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CcL-WC-3WC">
-                                        <rect key="frame" x="18" y="88" width="79" height="17"/>
+                                        <rect key="frame" x="18" y="87" width="79" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Dimensions:" id="6Sz-kB-Jau">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -66,7 +67,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="BWw-q9-45K" customClass="MenuPopUpButton" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="99" y="83" width="269" height="25"/>
+                                        <rect key="frame" x="99" y="81" width="269" height="25"/>
                                         <popUpButtonCell key="cell" type="push" title="Custom" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="HdF-GF-uLW" id="SEY-z7-JVq">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="menu"/>
@@ -79,7 +80,7 @@
                                         </popUpButtonCell>
                                     </popUpButton>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Jqk-p7-DIM" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="101" y="50" width="150" height="22"/>
+                                        <rect key="frame" x="101" y="49" width="150" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="150" id="f0p-wK-4JS"/>
                                         </constraints>
@@ -90,7 +91,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="76" translatesAutoresizingMaskIntoConstraints="NO" id="y55-Nm-2MG">
-                                        <rect key="frame" x="18" y="53" width="79" height="17"/>
+                                        <rect key="frame" x="18" y="52" width="79" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Width:" id="lvt-MD-r8L">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -98,7 +99,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bzf-LM-SxO" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="101" y="18" width="150" height="22"/>
+                                        <rect key="frame" x="101" y="18" width="150" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="150" id="rW2-DE-8b1"/>
                                         </constraints>
@@ -109,7 +110,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="76" translatesAutoresizingMaskIntoConstraints="NO" id="iPX-cO-cRP">
-                                        <rect key="frame" x="18" y="21" width="79" height="16"/>
+                                        <rect key="frame" x="18" y="21" width="79" height="15"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Height:" id="stb-YD-0DW">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -117,7 +118,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="aVG-zO-Cd7" customClass="MenuPopUpButton" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="263" y="32" width="105" height="25"/>
+                                        <rect key="frame" x="263" y="31" width="105" height="25"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="aVb-nw-wpN"/>
                                         </constraints>
@@ -163,13 +164,13 @@
                             </view>
                         </box>
                         <box titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="PQ8-dZ-N1k">
-                            <rect key="frame" x="405" y="-4" width="355" height="129"/>
+                            <rect key="frame" x="405" y="-4" width="355" height="127"/>
                             <view key="contentView" id="d7l-jL-VWi">
-                                <rect key="frame" x="3" y="3" width="349" height="123"/>
+                                <rect key="frame" x="3" y="3" width="349" height="121"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iFf-bP-MLi">
-                                        <rect key="frame" x="18" y="53" width="60" height="17"/>
+                                        <rect key="frame" x="18" y="53" width="60" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Quality:" id="K0X-2I-A0y">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -181,14 +182,14 @@
                                         <sliderCell key="cell" continuous="YES" alignment="left" minValue="0.5" maxValue="1" doubleValue="0.50459439766839376" tickMarkPosition="above" sliderType="linear" id="EO3-Q8-SDC"/>
                                     </slider>
                                     <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rej-Dl-z8Y">
-                                        <rect key="frame" x="82" y="86" width="218" height="19"/>
+                                        <rect key="frame" x="82" y="85" width="218" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="214" id="BIw-L9-Hls"/>
                                         </constraints>
                                         <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="5" maxValue="30" doubleValue="30" tickMarkPosition="above" sliderType="linear" id="aU8-ka-YW2"/>
                                     </slider>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="5Ke-gz-J2u" customClass="MonospacedLabel" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="304" y="88" width="27" height="17"/>
+                                        <rect key="frame" x="304" y="87" width="27" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="23" id="Pld-9q-pDl"/>
                                         </constraints>
@@ -199,21 +200,20 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="Fxs-GY-NUz">
-                                        <rect key="frame" x="18" y="88" width="60" height="17"/>
+                                        <rect key="frame" x="18" y="87" width="60" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="FPS:" id="O3d-Ep-9VJ">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iCr-ZN-9aI">
-                                        <rect key="frame" x="127" y="18" width="96" height="17"/>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Estimated size:" id="s0a-Dg-FJd">
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Mk2-3o-6CT">
+                                        <rect key="frame" x="82" y="19" width="97" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Infinite Loop" bezelStyle="regularSquare" imagePosition="left" inset="2" id="c3l-oV-Y0b">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
-                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                    </textField>
+                                        </buttonCell>
+                                    </button>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="5Ke-gz-J2u" secondAttribute="trailing" constant="20" symbolic="YES" id="2kR-fz-ftG"/>
@@ -221,16 +221,15 @@
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="leading" secondItem="iFf-bP-MLi" secondAttribute="leading" id="AOu-eR-uC7"/>
                                     <constraint firstItem="iFf-bP-MLi" firstAttribute="top" secondItem="Fxs-GY-NUz" secondAttribute="bottom" constant="18" id="BdX-Ip-Sfw"/>
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="trailing" secondItem="iFf-bP-MLi" secondAttribute="trailing" id="HTv-ji-VLV"/>
-                                    <constraint firstItem="iCr-ZN-9aI" firstAttribute="centerX" secondItem="d7l-jL-VWi" secondAttribute="centerX" id="JDm-GZ-k2I"/>
                                     <constraint firstItem="iFf-bP-MLi" firstAttribute="baseline" secondItem="wmm-UU-g6g" secondAttribute="baseline" id="JaM-6Y-r2w"/>
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="leading" secondItem="d7l-jL-VWi" secondAttribute="leading" constant="20" symbolic="YES" id="LrM-Ia-FKl"/>
-                                    <constraint firstAttribute="bottom" secondItem="iCr-ZN-9aI" secondAttribute="bottom" constant="18" id="MDf-IF-h95"/>
-                                    <constraint firstItem="iCr-ZN-9aI" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iFf-bP-MLi" secondAttribute="top" constant="8" id="OFk-7C-xQR"/>
                                     <constraint firstItem="Rej-Dl-z8Y" firstAttribute="trailing" secondItem="wmm-UU-g6g" secondAttribute="trailing" id="PvJ-zU-xzT"/>
+                                    <constraint firstItem="Mk2-3o-6CT" firstAttribute="top" secondItem="wmm-UU-g6g" secondAttribute="bottom" constant="18" id="QeK-R7-HH4"/>
                                     <constraint firstItem="5Ke-gz-J2u" firstAttribute="firstBaseline" secondItem="Fxs-GY-NUz" secondAttribute="firstBaseline" id="YcA-vG-aBS"/>
                                     <constraint firstItem="5Ke-gz-J2u" firstAttribute="leading" secondItem="Rej-Dl-z8Y" secondAttribute="trailing" constant="8" symbolic="YES" id="eXk-Bv-HWg"/>
                                     <constraint firstItem="Rej-Dl-z8Y" firstAttribute="leading" secondItem="Fxs-GY-NUz" secondAttribute="trailing" constant="8" symbolic="YES" id="er2-bc-7th"/>
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="top" secondItem="d7l-jL-VWi" secondAttribute="top" constant="18" id="ivK-Jk-HzZ"/>
+                                    <constraint firstItem="Mk2-3o-6CT" firstAttribute="leading" secondItem="wmm-UU-g6g" secondAttribute="leading" id="qeA-E1-JIA"/>
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="firstBaseline" secondItem="Rej-Dl-z8Y" secondAttribute="firstBaseline" id="tLB-lC-RNe"/>
                                 </constraints>
                             </view>
@@ -247,10 +246,10 @@
                     </constraints>
                 </customView>
                 <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hHF-zN-Wqa">
-                    <rect key="frame" x="627" y="10" width="154" height="21"/>
+                    <rect key="frame" x="627" y="10" width="154" height="23"/>
                     <subviews>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AF4-ry-iae">
-                            <rect key="frame" x="-6" y="-7" width="82" height="32"/>
+                            <rect key="frame" x="-6" y="-5" width="82" height="32"/>
                             <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ZWE-2a-d8e">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -260,7 +259,7 @@
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="coA-lD-jim">
-                            <rect key="frame" x="71" y="-7" width="89" height="32"/>
+                            <rect key="frame" x="71" y="-5" width="89" height="32"/>
                             <buttonCell key="cell" type="push" title="Convert" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gbn-c3-6oW">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -282,10 +281,20 @@ DQ
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iCr-ZN-9aI">
+                    <rect key="frame" x="22" y="14" width="122" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Estimated File Size:" id="s0a-Dg-FJd">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="O0D-L4-chv" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="30" id="0c5-JS-PUZ"/>
                 <constraint firstItem="hHF-zN-Wqa" firstAttribute="top" secondItem="dmb-Gl-vWp" secondAttribute="bottom" constant="10" id="Ik7-TN-Ier"/>
+                <constraint firstItem="iCr-ZN-9aI" firstAttribute="leading" secondItem="dmb-Gl-vWp" secondAttribute="leading" id="Nzb-Zq-1nz"/>
+                <constraint firstItem="hHF-zN-Wqa" firstAttribute="centerY" secondItem="iCr-ZN-9aI" secondAttribute="centerY" id="S2X-yd-vbo"/>
                 <constraint firstItem="hHF-zN-Wqa" firstAttribute="trailing" secondItem="PQ8-dZ-N1k" secondAttribute="trailing" id="YKH-2e-sJa"/>
                 <constraint firstAttribute="trailing" secondItem="dmb-Gl-vWp" secondAttribute="trailing" constant="24" id="dQw-6m-2yr"/>
                 <constraint firstAttribute="bottom" secondItem="hHF-zN-Wqa" secondAttribute="bottom" constant="10" id="hjJ-IT-g7h"/>

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -32,17 +32,19 @@ final class Gifski {
 		let quality: Double
 		let dimensions: CGSize?
 		let frameRate: Int?
+		let singleIteration: Bool
 
 		// TODO: With Swift 5.1 we can remove the manual `init` and have it synthesized.
 		/**
 		- Parameter frameRate: Clamped to 5...30. Uses the frame rate of `input` if not specified.
 		*/
-		init(video: URL, timeRange: ClosedRange<Double>? = nil, quality: Double = 1, dimensions: CGSize? = nil, frameRate: Int? = nil) {
+		init(video: URL, timeRange: ClosedRange<Double>? = nil, quality: Double = 1, dimensions: CGSize? = nil, frameRate: Int? = nil, singleIteration: Bool = false) {
 			self.video = video
 			self.timeRange = timeRange
 			self.quality = quality
 			self.dimensions = dimensions
 			self.frameRate = frameRate
+			self.singleIteration = singleIteration
 		}
 	}
 
@@ -78,7 +80,7 @@ final class Gifski {
 			width: UInt32(conversion.dimensions?.width ?? 0),
 			height: UInt32(conversion.dimensions?.height ?? 0),
 			quality: UInt8(conversion.quality * 100),
-			once: false,
+			once: conversion.singleIteration,
 			fast: false
 		)
 


### PR DESCRIPTION
Resolves https://github.com/sindresorhus/Gifski/issues/137

Note that QuickLook doesn't seem to respect iteration counts and loops the preview in any case.
Correct output can be verified with [ExifTool](https://www.sno.phy.queensu.ca/~phil/exiftool/), which should print `Animation Iterations : 1` when Infinite Loop option is disabled.