### PR TITLE
Make the feedback button not open GitHub

### DIFF
--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -27,25 +27,20 @@ func delay(seconds: TimeInterval, closure: @escaping () -> Void) {
 
 
 struct Meta {
-	static func openSubmitFeedbackPage(message: String? = nil) {
-		let defaultMessage = "<!--\nProvide your feedback here. Include as many details as possible.\nYou can also email me at sindresorhus@gmail.com\n-->"
-
-		let body =
+	static func openSubmitFeedbackPage() {
+		let metadata =
 			"""
-			\(message ?? defaultMessage)
-
-
-			---
-			\(App.name) \(App.versionWithBuild)
+			\(App.name) \(App.versionWithBuild) - \(App.id)
 			macOS \(System.osVersion)
 			\(System.hardwareModel)
 			"""
 
 		let query: [String: String] = [
-			"body": body
+			"product": App.name,
+			"metadata": metadata
 		]
 
-		URL(string: "https://github.com/sindresorhus/Gifski/issues/new")!.addingDictionaryAsQuery(query).open()
+		URL(string: "https://sindresorhus.com/feedback/")!.addingDictionaryAsQuery(query).open()
 	}
 }
 


### PR DESCRIPTION
Instead, it now opens my feedback form, which is more user-friendly. Many of our users are not on GitHub, so we're missing out on important feedback. I've added a detection to my form, so when it's Gifski, it adds a note about opening an issue if the user has a GitHub account.

Example form: https://sindresorhus.com/feedback/?product=Gifski&metadata=Gifski%202.1.1%20%2821%29%20-%20com.sindresorhus.Gifski%0AmacOS%2010.15.0%0AMacBookPro11%2C3

The text there is:

> If you're on GitHub, [open an issue on the repo]() instead.

I could use some feedback on how to improve it.