### PR TITLE
Handle video track duration being shorter than total duration

### DIFF
--- a/Gifski/VideoValidator.swift
+++ b/Gifski/VideoValidator.swift
@@ -96,7 +96,7 @@ struct VideoValidator {
 			return .failure
 		}
 
-		// If the video track duration is shorter than the total asset duration, we extract the video track into a new asset to prevent problems later on.
+		// If the video track duration is shorter than the total asset duration, we extract the video track into a new asset to prevent problems later on. If we don't do this, the video will show as black in the trim view at the duration where there's no video track, and it will confuse users. Also, if the user trims the video to just the black no video track part, the conversion would continue, but there's nothing to convert, so it would be stuck at 0%.
 		guard firstVideoTrack.isFullDuration else {
 			guard
 				let newAsset = firstVideoTrack.extractToNewAsset(),

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -619,6 +619,31 @@ extension AVAssetTrack {
 	}
 }
 
+extension AVAssetTrack {
+	/// Whether the track's duration is the same as the total asset duration.
+	var isFullDuration: Bool { timeRange.duration == asset?.duration }
+
+	/**
+	Extract the track into a new AVAsset.
+
+	This can be useful if you only want the video or audio of an asset. For example, sometimes the video track duration is shorter than the total asset duration. Extracting the track into a new asset ensures the asset duration is only as long as the video track duration.
+	*/
+	func extractToNewAsset() -> AVAsset? {
+		let composition = AVMutableComposition()
+
+		guard
+			let track = composition.addMutableTrack(withMediaType: mediaType, preferredTrackID: kCMPersistentTrackID_Invalid),
+			((try? track.insertTimeRange(CMTimeRange(start: .zero, duration: timeRange.duration), of: self, at: .zero)) != nil)
+		else {
+			return nil
+		}
+
+		track.preferredTransform = preferredTransform
+
+		return composition
+	}
+}
+
 
 /*
 > FOURCC is short for "four character code" - an identifier for a video codec, compression format, color or pixel format used in media files.


### PR DESCRIPTION
Fixes #119
Fixes #164

Someone finally submitted a video that reproduces the issue and I discovered why it's happening. Apparently, a video file can contain a video track that is shorter than the total file duration. We generated frame time points for the whole asset, even outside the video track. That's why `generateCGImagesAsynchronously` errored. We tried to get a frame from the video when there were none.