### PR TITLE
Fix crash on cancel

### DIFF
--- a/Gifski.xcodeproj/xcshareddata/xcschemes/Gifski.xcscheme
+++ b/Gifski.xcodeproj/xcshareddata/xcschemes/Gifski.xcscheme
@@ -54,6 +54,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
       enableASanStackUseAfterReturn = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"

--- a/Gifski/ConversionViewController.swift
+++ b/Gifski/ConversionViewController.swift
@@ -18,6 +18,7 @@ final class ConversionViewController: NSViewController {
 	private var conversion: Gifski.Conversion!
 	private var progress: Progress?
 	private var isRunning = false
+	private let gifski = Gifski()
 
 	convenience init(conversion: Gifski.Conversion) {
 		self.init()
@@ -77,7 +78,7 @@ final class ConversionViewController: NSViewController {
 		timeRemainingEstimator.start()
 
 		progress?.performAsCurrent(withPendingUnitCount: 1) { [weak self] in
-			Gifski.run(conversion) { result in
+			gifski.run(conversion) { result in
 				guard let self = self else {
 					return
 				}


### PR DESCRIPTION
I finally had some time to sit down and look into this. The problem was that `progress` was just a local variable, so it was not retained long enough. Moving Gifski to be an instance fixes this.

You can reproduce the crash by building master (63cbde3a7352fca1c74a936a99e698c694a755da) in release mode, converting [this fixture](https://github.com/sindresorhus/Gifski/files/3912180/Fixture.zip), and then canceling around 3%. With this PR, it's no longer reproducible.
