### PR TITLE
Add back button to the conversion completed view

### DIFF
--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -7,6 +7,8 @@ import Crashlytics
 final class AppDelegate: NSObject, NSApplicationDelegate {
 	lazy var mainWindowController = MainWindowController()
 
+	var previousEditViewController: EditVideoViewController?
+
 	// Possible workaround for crashing bug because of Crashlytics swizzling.
 	let notificationCenter = UNUserNotificationCenter.current()
 

--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -156,6 +156,11 @@ final class ConversionCompletedViewController: NSViewController {
 		let videoDropController = VideoDropViewController(dropLabelIsHidden: true)
 		add(childController: videoDropController)
 	}
+
+	@IBAction private func backButton(_ sender: NSButton) {
+		// It's safe to force-unwrap as there's no scenario where it will be nil.
+		push(viewController: AppDelegate.shared.previousEditViewController!)
+	}
 }
 
 extension ConversionCompletedViewController: QLPreviewPanelDataSource {

--- a/Gifski/ConversionCompletedViewController.xib
+++ b/Gifski/ConversionCompletedViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14845" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14845"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -90,6 +90,17 @@
                                 <real value="3.4028234663852886e+38"/>
                             </customSpacing>
                         </stackView>
+                        <button verticalHuggingPriority="750" id="wfU-Sw-FaI" customClass="BackButton" customModule="Gifski" customModuleProvider="target">
+                            <rect key="frame" x="30" y="188" width="30" height="23"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" alignment="center" borderStyle="border" inset="2" id="LUC-j4-xY8">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="backButton:" target="-2" id="rTe-95-NTz"/>
+                            </connections>
+                        </button>
                     </subviews>
                     <constraints>
                         <constraint firstItem="9j4-tJ-yJo" firstAttribute="top" relation="greaterThanOrEqual" secondItem="1a5-4g-xpl" secondAttribute="top" id="9cQ-Vd-LOp"/>

--- a/Gifski/ConversionViewController.swift
+++ b/Gifski/ConversionViewController.swift
@@ -109,9 +109,9 @@ final class ConversionViewController: NSViewController {
 			progress?.cancel()
 		}
 
-		let videoDropController = VideoDropViewController()
 		stopConversion { [weak self] in
-			self?.push(viewController: videoDropController)
+			// It's safe to force-unwrap as there's no scenario where it will be nil.
+			self?.push(viewController: AppDelegate.shared.previousEditViewController!)
 		}
 	}
 

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -59,6 +59,8 @@ final class EditVideoViewController: NSViewController {
 		self.inputUrl = inputUrl
 		self.asset = asset
 		self.videoMetadata = videoMetadata
+
+		AppDelegate.shared.previousEditViewController = self
 	}
 
 	@IBAction private func convert(_ sender: Any) {

--- a/Gifski/VideoDropViewController.swift
+++ b/Gifski/VideoDropViewController.swift
@@ -10,10 +10,8 @@ struct DropCenterView: View {
 				.font(.system(size: 10))
 				.italic()
 				.padding(.top, 6)
-			Button(action: {
+			Button("Open") {
 				AppDelegate.shared.mainWindowController.presentOpenPanel()
-			}) {
-				Text("Open")
 			}
 		}
 			.foregroundColor(.secondary)

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2765,3 +2765,21 @@ final class LaunchCompletions {
 		finishedLaunchingCompletions = []
 	}
 }
+
+
+@IBDesignable
+class BackButton: NSButton {
+	convenience init() {
+		self.init()
+		commonInit()
+	}
+
+	override func awakeFromNib() {
+		super.awakeFromNib()
+		commonInit()
+	}
+
+	private func commonInit() {
+		self.image = NSImage(named: NSImage.goBackTemplateName)
+	}
+}


### PR DESCRIPTION
Also go back to the edit view when cancelling the conversion.

I went for a simple pragmatic solution of just storing the previous edit controller. Seems to work fine. We'll eventually rewrite all the views in SwiftUI anyway, so no point in spending too much time perfecting stuff.

<img width="472" alt="Screenshot 2019-12-19 at 12 16 48" src="https://user-images.githubusercontent.com/170270/71169580-96767200-2259-11ea-820b-c2c34468dd9f.png">

Fixes #112
Closes #133