### PR TITLE
Work around bug where width/height text fields are not editable

### DIFF
--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2541,6 +2541,11 @@ extension NSViewController {
 		let newWindowFrame = CGRect(origin: newOrigin, size: viewController.view.frame.size)
 
 		viewController.view.alphaValue = 0.0
+
+		// Workaround for macOS first responder quirk. Still in macOS 10.15.3.
+		// Reproduce: Without the below, if you click convert, hide the window, show the window when the conversion is done, and then drag and drop a new file, the width/height text fields are now not editable.
+		window.makeFirstResponder(viewController)
+
 		NSAnimationContext.runAnimationGroup({ _ in
 			window.contentViewController?.view.animator().alphaValue = 0.0
 			window.contentViewController = nil


### PR DESCRIPTION
Fixes #122

We previously removed this call to work around Quick Look not working (https://github.com/sindresorhus/Gifski/pull/107/files#diff-75a4e71e51a82ac8607443b8f202430eL2452), but the call is now added before the animation, not after. Everything seems to work, including Quick Look.

I failed to find a better fix for this and I've wasted enough time on this now. We'll rewrite stuff in SwiftUI at some point anyway.