### PR TITLE
Fix trimming from the start

### DIFF
--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -253,7 +253,7 @@ final class Gifski {
 							bytesPerRow: UInt32(image.bytesPerRow),
 							height: UInt32(image.height),
 							pixels: buffer,
-							presentationTimestamp: result.actualTime.seconds
+							presentationTimestamp: max(0, result.actualTime.seconds - startTime)
 						)
 					} catch {
 						completionHandlerOnce(.failure(.addFrameFailed(error)))


### PR DESCRIPTION
I got a report that the first frame froze for a long time on their GIF. After a lot of debugging, it turns out after the 60 FPS changes, I forgot to adjust the presentation timestamp passed to libgifski when the video is trimmed.