### PR TITLE
Improve the legibility of the progress circle in dark mode

### DIFF
--- a/Gifski/Assets.xcassets/ProgressCircleColor.colorset/Contents.json
+++ b/Gifski/Assets.xcassets/ProgressCircleColor.colorset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "mac",
+      "color" : {
+        "platform" : "osx",
+        "reference" : "controlAccentColor"
+      }
+    },
+    {
+      "idiom" : "mac",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "platform" : "osx",
+        "reference" : "labelColor"
+      }
+    }
+  ]
+}

--- a/Gifski/Constants.swift
+++ b/Gifski/Constants.swift
@@ -9,6 +9,7 @@ struct Constants {
 
 extension NSColor {
 	static let themeColor = NSColor.controlAccentColorPolyfill
+	static let progressCircleColor = NSColor(named: "ProgressCircleColor")!
 
 	enum Checkerboard {
 		static let first = NSColor(named: "CheckerboardFirstColor")!

--- a/Gifski/ConversionViewController.swift
+++ b/Gifski/ConversionViewController.swift
@@ -6,14 +6,15 @@ import Defaults
 final class ConversionViewController: NSViewController {
 	private lazy var circularProgress = with(CircularProgress(size: 160.0)) {
 		$0.translatesAutoresizingMaskIntoConstraints = false
-		$0.color = .themeColor
+		$0.color = .progressCircleColor
+		$0.lineWidth = 3
 	}
 
 	private lazy var timeRemainingLabel = with(Label()) {
 		$0.translatesAutoresizingMaskIntoConstraints = false
 		$0.isHidden = true
 		$0.textColor = .secondaryLabelColor
-		$0.font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .regular)
+		$0.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
 	}
 
 	private lazy var timeRemainingEstimator = TimeRemainingEstimator(label: timeRemainingLabel)


### PR DESCRIPTION
We use the user's accent color for the progress circle. Because the window is vibrant, the progress circle is not very legible in dark mode:

<img width="424" alt="Screenshot 2020-02-06 at 15 52 40" src="https://user-images.githubusercontent.com/170270/73921043-31560900-48f9-11ea-88b5-37c967f964ff.png">

I tried making the color brighter, but I couldn't make it look very good.

I suggest we make it just white in dark mode. This looks pretty good:

<img width="431" alt="Screenshot 2020-02-06 at 15 39 43" src="https://user-images.githubusercontent.com/170270/73921204-82fe9380-48f9-11ea-9bdf-c5c7a80354d4.png">

I've also changed the line width from 2 to 3.

The question then is what should we do in light mode?

The blue accent color looks fine:

<img width="417" alt="Screenshot 2020-02-06 at 15 54 29" src="https://user-images.githubusercontent.com/170270/73921335-b50ff580-48f9-11ea-8451-43040f10b8b2.png">

But if the user (for some crazy reason) has orange as accent color, it becomes less legible:

<img width="417" alt="Screenshot 2020-02-06 at 15 48 45" src="https://user-images.githubusercontent.com/170270/73921393-d5d84b00-48f9-11ea-8a99-8c7f5ebb5047.png">

And this is how using `.labelColor`, which is used in dark mode, would look in light mode:

<img width="423" alt="Screenshot 2020-02-06 at 15 37 54" src="https://user-images.githubusercontent.com/170270/73921487-04562600-48fa-11ea-8d2d-854b9c6d4927.png">

Looks pretty good to me.

**So the question is, should light mode use accent color or just label color like dark mode**? I'm leaning towards the latter.