### PR TITLE
Loop the playback when “Loop Forever” is enabled

### DIFF
--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -302,6 +302,12 @@ final class EditVideoViewController: NSViewController {
 		playerViewController = TrimmingAVPlayerViewController(playerItem: AVPlayerItem(asset: asset)) { [weak self] _ in
 			self?.estimateFileSize()
 		}
+
+		Defaults.observe(.loopGif) { [weak self] in
+			self?.playerViewController.loopPlayback = $0.newValue
+		}
+			.tieToLifetime(of: self)
+
 		add(childController: playerViewController, to: playerViewWrapper)
 	}
 

--- a/Gifski/TrimmingAVPlayerViewController.swift
+++ b/Gifski/TrimmingAVPlayerViewController.swift
@@ -5,6 +5,7 @@ import Defaults
 final class TrimmingAVPlayerViewController: NSViewController {
 	private(set) var timeRange: ClosedRange<Double>?
 	private let playerItem: AVPlayerItem
+	private let player: AVPlayer
 	private let controlsStyle: AVPlayerViewControlsStyle
 	private let timeRangeDidChange: ((ClosedRange<Double>) -> Void)?
 
@@ -17,12 +18,22 @@ final class TrimmingAVPlayerViewController: NSViewController {
 		}
 	}
 
+	var loopPlayback: Bool {
+		get {
+			player.loopPlayback
+		}
+		set {
+			player.loopPlayback = newValue
+		}
+	}
+
 	init(
 		playerItem: AVPlayerItem,
 		controlsStyle: AVPlayerViewControlsStyle = .inline,
 		timeRangeDidChange: ((ClosedRange<Double>) -> Void)? = nil
 	) {
 		self.playerItem = playerItem
+		self.player = AVPlayer(playerItem: playerItem)
 		self.controlsStyle = controlsStyle
 		self.timeRangeDidChange = timeRangeDidChange
 		super.init(nibName: nil, bundle: nil)
@@ -34,18 +45,10 @@ final class TrimmingAVPlayerViewController: NSViewController {
 	}
 
 	override func loadView() {
-		let player = AVPlayer(playerItem: playerItem)
-
-		Defaults.observe(.loopGif) {
-			player.loopPlayback = $0.newValue
-		}
-			.tieToLifetime(of: self)
-
 		let playerView = TrimmingAVPlayerView()
 		playerView.controlsStyle = controlsStyle
 		playerView.setupTrimmingObserver()
 		playerView.player = player
-
 		view = playerView
 	}
 

--- a/Gifski/TrimmingAVPlayerViewController.swift
+++ b/Gifski/TrimmingAVPlayerViewController.swift
@@ -1,5 +1,4 @@
 import AVKit
-import Defaults
 
 /// VC containing AVPlayerView and also extending possibilities for trimming (view) customization.
 final class TrimmingAVPlayerViewController: NSViewController {

--- a/Gifski/TrimmingAVPlayerViewController.swift
+++ b/Gifski/TrimmingAVPlayerViewController.swift
@@ -1,4 +1,5 @@
 import AVKit
+import Defaults
 
 /// VC containing AVPlayerView and also extending possibilities for trimming (view) customization.
 final class TrimmingAVPlayerViewController: NSViewController {
@@ -33,10 +34,17 @@ final class TrimmingAVPlayerViewController: NSViewController {
 	}
 
 	override func loadView() {
+		let player = AVPlayer(playerItem: playerItem)
+
+		Defaults.observe(.loopGif) {
+			player.loopPlayback = $0.newValue
+		}
+			.tieToLifetime(of: self)
+
 		let playerView = TrimmingAVPlayerView()
-		playerView.player = AVPlayer(playerItem: playerItem)
 		playerView.controlsStyle = controlsStyle
 		playerView.setupTrimmingObserver()
+		playerView.player = player
 
 		view = playerView
 	}

--- a/Gifski/VideoValidator.swift
+++ b/Gifski/VideoValidator.swift
@@ -96,30 +96,21 @@ struct VideoValidator {
 			return .failure
 		}
 
-		// If the video track duration is shorter than the total asset duration, we extract the video track into a new asset to prevent problems later on. If we don't do this, the video will show as black in the trim view at the duration where there's no video track, and it will confuse users. Also, if the user trims the video to just the black no video track part, the conversion would continue, but there's nothing to convert, so it would be stuck at 0%.
-		guard firstVideoTrack.isFullDuration else {
-			guard
-				let newAsset = firstVideoTrack.extractToNewAsset(),
-				let newVideoMetadata = newAsset.videoMetadata
-			else {
-				NSAlert.showModalAndReportToCrashlytics(
-					for: window,
-					message: "Cannot read the video.",
-					informativeText: "Please open an issue on https://github.com/sindresorhus/Gifski or email sindresorhus@gmail.com. ZIP the video and attach it.\n\nInclude this info:",
-					debugInfo: asset.debugInfo
-				)
-
-				return .failure
-			}
-
-			Crashlytics.record(
-				key: "Extracted video to new asset",
-				value: true
+		// We extract the video track into a new asset to remove the audio and to prevent problems if the video track duration is shorter than the total asset duration. If we don't do this, the video will show as black in the trim view at the duration where there's no video track, and it will confuse users. Also, if the user trims the video to just the black no video track part, the conversion would continue, but there's nothing to convert, so it would be stuck at 0%.
+		guard
+			let newAsset = firstVideoTrack.extractToNewAsset(),
+			let newVideoMetadata = newAsset.videoMetadata
+		else {
+			NSAlert.showModalAndReportToCrashlytics(
+				for: window,
+				message: "Cannot read the video.",
+				informativeText: "This should not happen. Email sindresorhus@gmail.com and include this info:",
+				debugInfo: asset.debugInfo
 			)
 
-			return .success(newAsset, newVideoMetadata)
+			return .failure
 		}
 
-		return .success(asset, videoMetadata)
+		return .success(newAsset, newVideoMetadata)
 	}
 }

--- a/Gifski/VideoValidator.swift
+++ b/Gifski/VideoValidator.swift
@@ -71,7 +71,7 @@ struct VideoValidator {
 			return .failure
 		}
 
-		guard let videoMetadata = asset.videoMetadata else {
+		guard asset.videoMetadata != nil else {
 			NSAlert.showModalAndReportToCrashlytics(
 				for: window,
 				message: "The video metadata is not readable.",

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2986,6 +2986,7 @@ extension AVPlayer {
 			} else {
 				actionAtItemEnd = AssociatedKeys.originalActionAtItemEnd[self] ?? actionAtItemEnd
 				AssociatedKeys.originalActionAtItemEnd[self] = nil
+				AssociatedKeys.observationToken[self] = nil
 			}
 		}
 	}


### PR DESCRIPTION
I tried using [`AVPlayerLooper`](https://developer.apple.com/documentation/avfoundation/avplayerlooper) first, but that removes the editing controls when looping. The looping seems smooth using the current method anyway.