### PR TITLE
Ensure there are enough frames

### DIFF
--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -21,7 +21,7 @@ final class Gifski {
 			case .unreadableFile:
 				return "The selected file is no longer readable."
 			case let .notEnoughFrames(frameCount):
-				return "An animated GIF requires at least 2 frames. Your video only has \(frameCount) frame\(frameCount == 1 ? "" : "s")."
+				return "An animated GIF requires a minimum of 2 frames. Your video contains \(frameCount) frame\(frameCount == 1 ? "" : "s")."
 			case let .generateFrameFailed(error):
 				return "Failed to generate frame: \(error.localizedDescription)"
 			case let .addFrameFailed(error):


### PR DESCRIPTION
Previously, if there were not enough frames, the progress bar would show and just stay there without anything happening.

Not enough frames could happen on very short videos or if the user trims too much.

<img width="472" alt="Screenshot 2020-02-10 at 20 16 19" src="https://user-images.githubusercontent.com/170270/74153032-35a85c00-4c42-11ea-99a7-e5f98f0214a2.png">
