### PR TITLE
Fix a crash that can sometimes happen when cancelling

### DIFF
--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -71,6 +71,13 @@ final class Gifski {
 		progress = Progress(parent: .current())
 
 		let completionHandlerOnce = Once().wrap { [weak self] (_ result: Result<Data, Error>) -> Void in
+			if
+				case .failure(let error) = result,
+				case .cancelled = error
+			{
+				try? self?.gifski?.finish()
+			}
+
 			self?.gifski?.release()
 
 			DispatchQueue.main.async {

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -5,6 +5,9 @@ import Crashlytics
 var conversionCount = 0
 
 final class Gifski {
+	deinit {
+		print("GIFSKI DEINIT")
+	}
 	enum Error: LocalizedError {
 		case invalidSettings
 		case unreadableFile
@@ -49,6 +52,7 @@ final class Gifski {
 
 	private var gifData = NSMutableData()
 	private var progress: Progress!
+	private var gifski: GifskiWrapper?
 
 	// TODO: Split this method up into smaller methods. It's too large.
 	/**
@@ -67,6 +71,8 @@ final class Gifski {
 		progress = Progress(parent: .current())
 
 		let completionHandlerOnce = Once().wrap { [weak self] (_ result: Result<Data, Error>) -> Void in
+			self?.gifski?.release()
+
 			DispatchQueue.main.async {
 				guard
 					let self = self,
@@ -88,7 +94,9 @@ final class Gifski {
 			fast: false
 		)
 
-		guard let gifski = GifskiWrapper(settings: settings) else {
+		self.gifski = GifskiWrapper(settings: settings)
+
+		guard let gifski = gifski else {
 			completionHandlerOnce(.failure(.invalidSettings))
 			return
 		}

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -5,9 +5,6 @@ import Crashlytics
 var conversionCount = 0
 
 final class Gifski {
-	deinit {
-		print("GIFSKI DEINIT")
-	}
 	enum Error: LocalizedError {
 		case invalidSettings
 		case unreadableFile

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -71,13 +71,8 @@ final class Gifski {
 		progress = Progress(parent: .current())
 
 		let completionHandlerOnce = Once().wrap { [weak self] (_ result: Result<Data, Error>) -> Void in
-			if
-				case .failure(let error) = result,
-				case .cancelled = error
-			{
-				try? self?.gifski?.finish()
-			}
-
+			// Ensure libgifski finishes no matter what.
+			try? self?.gifski?.finish()
 			self?.gifski?.release()
 
 			DispatchQueue.main.async {

--- a/Gifski/GifskiWrapper.swift
+++ b/Gifski/GifskiWrapper.swift
@@ -154,9 +154,9 @@ final class GifskiWrapper {
 			return
 		}
 
-		try wrap { gifski_finish(pointer) }
-
 		hasFinished = true
+
+		try wrap { gifski_finish(pointer) }
 	}
 
 	func release() {

--- a/Gifski/GifskiWrapper.swift
+++ b/Gifski/GifskiWrapper.swift
@@ -78,8 +78,10 @@ final class GifskiWrapper {
 
 	typealias WriteCallback = (Int, UnsafePointer<UInt8>) -> Int
 
+	private var writeCallback: WriteCallback!
+
 	func setWriteCallback(_ callback: @escaping WriteCallback) {
-		var callback = callback
+		writeCallback = callback
 
 		gifski_set_write_callback(
 			pointer,
@@ -94,7 +96,7 @@ final class GifskiWrapper {
 				let callback = context!.assumingMemoryBound(to: WriteCallback.self).pointee
 				return Int32(callback(bufferLength, bufferPointer))
 			},
-			&callback
+			&writeCallback
 		)
 	}
 

--- a/Gifski/GifskiWrapper.swift
+++ b/Gifski/GifskiWrapper.swift
@@ -162,8 +162,4 @@ final class GifskiWrapper {
 	func release() {
 		unmanagedSelf.release()
 	}
-
-	deinit {
-		print("GIFSKIWRAPPER DEINIT")
-	}
 }

--- a/Gifski/GifskiWrapper.swift
+++ b/Gifski/GifskiWrapper.swift
@@ -51,6 +51,7 @@ enum GifskiWrapperError: UInt32, LocalizedError {
 final class GifskiWrapper {
 	private let pointer: OpaquePointer
 	private var unmanagedSelf: Unmanaged<GifskiWrapper>!
+	private var hasFinished = false
 
 	init?(settings: GifskiSettings) {
 		var settings = settings
@@ -78,6 +79,10 @@ final class GifskiWrapper {
 	private var progressCallback: ProgressCallback!
 
 	func setProgressCallback(_ callback: @escaping ProgressCallback) {
+		guard !hasFinished else {
+			return
+		}
+
 		progressCallback = callback
 
 		gifski_set_progress_callback(
@@ -95,6 +100,10 @@ final class GifskiWrapper {
 	private var writeCallback: WriteCallback!
 
 	func setWriteCallback(_ callback: @escaping WriteCallback) {
+		guard !hasFinished else {
+			return
+		}
+
 		writeCallback = callback
 
 		gifski_set_write_callback(
@@ -123,6 +132,10 @@ final class GifskiWrapper {
 		pixels: UnsafePointer<UInt8>,
 		presentationTimestamp: Double
 	) throws {
+		guard !hasFinished else {
+			return
+		}
+
 		try wrap {
 			gifski_add_frame_argb(
 				pointer,
@@ -137,7 +150,13 @@ final class GifskiWrapper {
 	}
 
 	func finish() throws {
+		guard !hasFinished else {
+			return
+		}
+
 		try wrap { gifski_finish(pointer) }
+
+		hasFinished = true
 	}
 
 	func release() {


### PR DESCRIPTION
I'm yet again looking into the crash that sometimes happen when you cancel the conversion.

This time, I'm trying the trick mentioned in https://forums.developer.apple.com/message/255978#255978 to be able to create normal callbacks from a C-based callbacks at the GifskiWrapper level. This makes it easier to ensure a weak self and prevent accidentally retaining self.

However, when trying to convert, I'm seeing a "Use of stack memory after return" address sanitizer issue at https://github.com/sindresorhus/Gifski/pull/189/files#diff-1df33fd7967eaf75e9f4c10c855f03f7R94 and https://github.com/ImageOptim/gifski/blob/a94b2828b33014bdf1704a97c3040acb023c8a2e/src/c_api.rs#L316 @kornelski Are you sure there's nothing in libgifski that is incorrectly retaining the pointer or something?