### PR TITLE
Warn users when copying that some apps cannot handle pasting animated GIFs

### DIFF
--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -120,6 +120,21 @@ final class ConversionCompletedViewController: NSViewController {
 			self.copyButton.title = "Copied!"
 			self.copyButton.isEnabled = false
 
+			App.runOnce(identifier: "copyWarning") {
+				NSAlert.showModal(
+					for: self.copyButton.window,
+					message: "The GIF was copied to the clipboard.",
+					informativeText: "However…",
+					buttonTitles: ["Continue"]
+				)
+
+				NSAlert.showModal(
+					for: self.copyButton.window,
+					message: "Please read!",
+					informativeText: "Many apps like Chrome and Slack do not properly handle copied animated GIFs and will paste them as non-animated PNG.\n\nInstead, drag and drop the GIF into such apps."
+				)
+			}
+
 			delay(seconds: 1) { [weak self] in
 				guard let self = self else {
 					return

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -1495,6 +1495,17 @@ struct App {
 	}
 }
 
+extension App {
+	static func runOnce(identifier: String, _ execute: () -> Void) {
+		let key = "SS_App_runOnce__\(identifier)"
+
+		if !UserDefaults.standard.bool(forKey: key) {
+			UserDefaults.standard.set(true, forKey: key)
+			execute()
+		}
+	}
+}
+
 
 /// Convenience for opening URLs.
 extension URL {


### PR DESCRIPTION
Someone complained in a review that Gifski produces a broken GIF when copying, not understanding that it's [Chrome (and Chrome-based apps) that suck](https://twitter.com/sindresorhus/status/1271001198422683648). This makes it clear.

Why two alerts? Because from experience a lot of users would just click away the first one without reading.

The alerts are only shown once.

I have the same alerts in my [Jiffy app](https://sindresorhus.com/jiffy) too.

**Feedback wanted on the alert text.**