### PR TITLE
Improve file size estimate

### DIFF
--- a/Gifski/ConversionViewController.swift
+++ b/Gifski/ConversionViewController.swift
@@ -80,7 +80,7 @@ final class ConversionViewController: NSViewController {
 				return
 			}
 
-			gifski.run(conversion) { result in
+			gifski.run(conversion, isEstimation: false) { result in
 				do {
 					let gifUrl = try self.generateTemporaryGifUrl(for: conversion.video)
 					try result.get().write(to: gifUrl, options: .atomic)

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -49,6 +49,17 @@ final class EditVideoViewController: NSViewController {
 		maxWidth: 300
 	)
 
+	private var conversionSettings: Gifski.Conversion {
+		.init(
+			video: inputUrl,
+			timeRange: timeRange,
+			quality: Defaults[.outputQuality],
+			dimensions: resizableDimensions.changed(dimensionsType: .pixels).currentDimensions.value,
+			frameRate: frameRateSlider.integerValue,
+			loopGif: Defaults[.loopGif]
+		)
+	}
+
 	convenience init(
 		inputUrl: URL,
 		asset: AVAsset,
@@ -65,16 +76,7 @@ final class EditVideoViewController: NSViewController {
 
 	@IBAction
 	private func convert(_ sender: Any) {
-		let conversion = Gifski.Conversion(
-			video: inputUrl,
-			timeRange: timeRange,
-			quality: Defaults[.outputQuality],
-			dimensions: resizableDimensions.changed(dimensionsType: .pixels).currentDimensions.value,
-			frameRate: frameRateSlider.integerValue,
-			loopGif: Defaults[.loopGif]
-		)
-
-		let convert = ConversionViewController(conversion: conversion)
+		let convert = ConversionViewController(conversion: conversionSettings)
 		push(viewController: convert)
 	}
 
@@ -340,7 +342,17 @@ final class EditVideoViewController: NSViewController {
 		selectPredefinedSizeBasedOnCurrentDimensions()
 	}
 
+	private func setEstimatedFileSize(_ string: String) {
+		estimatedSizeLabel.stringValue = "Estimated File Size: \(string)"
+	}
+
+	private var gifski: Gifski?
+
 	private func estimateFileSize() {
+		Debouncer.debounce(delay: 0.5, action: _estimateFileSize)
+	}
+
+	private func _estimateFileSize() {
 		let duration: Double = {
 			guard let timeRange = timeRange else {
 				return videoMetadata.duration
@@ -353,7 +365,38 @@ final class EditVideoViewController: NSViewController {
 		let dimensions = resizableDimensions.changed(dimensionsType: .pixels).currentDimensions.value
 		var fileSize = (Double(dimensions.width) * Double(dimensions.height) * frameCount) / 3
 		fileSize = fileSize * (qualitySlider.doubleValue + 1.5) / 2.5
-		estimatedSizeLabel.stringValue = "Estimated File Size: " + formatter.string(fromByteCount: Int64(fileSize))
+     // estimatedSizeLabel.stringValue = "Estimated File Size: " + formatter.string(fromByteCount: Int64(fileSize))
+
+		print("ESTIMATING")
+
+		// TODO: Deinit doesn't seem to be called.
+		self.gifski?.cancel()
+
+		let gifski = Gifski()
+		self.gifski = gifski
+
+		setEstimatedFileSize("… (Naive: \(formatter.string(fromByteCount: Int64(fileSize))))")
+
+		gifski.run(conversionSettings, isEstimation: true) { [weak self] result in
+			guard let self = self else {
+				return
+			}
+
+			switch result {
+			case .success(let data):
+				// We add 10% extra because it's better to estimate slightly too much than too little.
+				let fileSize = (Double(data.count) * gifski.sizeMultiplierForEstimation) * 1.1
+
+				self.setEstimatedFileSize(self.formatter.string(fromByteCount: Int64(fileSize)))
+			case .failure(let error):
+				switch error {
+				case .cancelled:
+					break
+				default:
+					error.presentAsModalSheet(for: self.view.window)
+				}
+			}
+		}
 	}
 
 	private func updateDimensionsDisplay() {

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -217,7 +217,7 @@ final class Gifski {
 				if originalCount > 25 {
 					frameForTimes = frameForTimes
 						.chunked(by: 5)
-						.sample(withSize: 5)
+						.sample(length: 5)
 						.flatten()
 				}
 

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -211,6 +211,7 @@ final class Gifski {
 				)
 			}
 
+			// TODO: The whole estimation thing should be split out into a separate method and the things that are shared should also be split out.
 			if isEstimation {
 				let originalCount = frameForTimes.count
 
@@ -221,8 +222,6 @@ final class Gifski {
 						.flatten()
 				}
 
-				print("Estimate frames", frameForTimes.count, frameForTimes.map(\.seconds))
-				print("Original count", originalCount)
 				self.sizeMultiplierForEstimation = Double(originalCount) / Double(frameForTimes.count)
 			}
 

--- a/Gifski/Utilities.swift
+++ b/Gifski/Utilities.swift
@@ -3372,10 +3372,13 @@ extension SSApp {
 }
 
 
-extension Array {
+extension Sequence {
 	/**
 	Returns an array of elements split into groups of the given size.
+
 	If it can't be split evenly, the final chunk will be the remaining elements.
+
+	If the requested chunk size is larger than the sequence, the chunk will be smaller than requested.
 
 	```
 	[1, 2, 3, 4].chunked(by: 2)
@@ -3383,17 +3386,27 @@ extension Array {
 	```
 	*/
 	func chunked(by chunkSize: Int) -> [[Element]] {
-		stride(from: 0, to: count, by: chunkSize).map {
-			Array(self[$0..<Swift.min($0 + chunkSize, count)])
+		reduce(into: []) { result, current in
+			if let last = result.last, last.count < chunkSize {
+				result.append(result.removeLast() + [current])
+			} else {
+				result.append([current])
+			}
 		}
 	}
 }
 
 
-extension Array {
-	func sample(withSize size: Int) -> [Element] {
-		precondition(size >= 0 && size <= count)
-		return (0..<size).map { self[($0 * count + count / 2) / size] }
+extension Collection where Index == Int {
+	/// Return a subset of the array of the given length by sampling "evenly distributed" elements.
+	func sample(length: Int) -> [Element] {
+		precondition(length >= 0, "The length cannot be negative.")
+
+		guard length < count else {
+			return Array(self)
+		}
+
+		return (0..<length).map { self[($0 * count + count / 2) / length] }
 	}
 }
 

--- a/Gifski/Utilities.swift
+++ b/Gifski/Utilities.swift
@@ -3543,7 +3543,7 @@ extension NSFont {
 		Self(descriptor: descriptor, size: 0) ?? self
 	}
 
-	// TODO: When Xcode 12 is out, use `[NSFont fontWithSize:]` when available.
+	// TODO: When Xcode 12.2 is out, use `[NSFont fontWithSize:]` when available.
 	/// Returns a font with the size replaced.
 	/// UIKit polyfill.
 	func withSize(_ size: CGFloat) -> NSFont {


### PR DESCRIPTION
I tried out many different algorithms and variants, and in the end, found that this one produced the most accurate estimate:
- Get all the normal frame time codes.
- Pick 5 consecutive samples from 5 evenly distributed places in the video.
- Convert with current settings.
- Divide by the original frame count compared to the one used in the estimate.

Fixes #41 

---

Here is a build: [Gifski - with estimate.zip](https://github.com/sindresorhus/Gifski/files/5388439/Gifski.-.with.estimate.zip)

**Please try it out on various videos and check the estimate compared to the final result. The most important part is that the estimate never shows less than the actual file.**

Note: The code and look are not done. It should be cleaned up a lot, but I would like to finalize the algorithm first.

Some potential optimization would be to run the 5 samples concurrently, but I don't plan to do that in this PR. I'll add a TODO comment.

---

Open questions:

- [x] Should we still show the naive estimate (the one we currently use) while the good estimate is being generated? Currently, the estimate takes from 5 - 15 seconds. The downside of showing the naive one is that it can be woefully incorrect sometimes. 