### PR TITLE
Limit frame rates to 50 FPS

### DIFF
--- a/Gifski/Constants.swift
+++ b/Gifski/Constants.swift
@@ -4,7 +4,7 @@ import Defaults
 struct Constants {
 	static let defaultWindowSize = CGSize(width: 360, height: 240)
 	static let backgroundImage = NSImage(named: "BackgroundImage")!
-	static let allowedFrameRate = 5.0...60.0
+	static let allowedFrameRate = 5.0...50.0
 }
 
 extension NSColor {

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -255,12 +255,28 @@ final class EditVideoViewController: NSViewController {
 		// We round it so that `29.970` becomes `30` for practical reasons.
 		let frameRate = videoMetadata.frameRate.rounded()
 
+		if frameRate > 50 {
+			showFpsWarningIfNeeded()
+		}
+
 		frameRateSlider.maxValue = frameRate.clamped(to: Constants.allowedFrameRate)
 		frameRateSlider.doubleValue = defaultFrameRate(inputFrameRate: frameRate)
 		frameRateSlider.triggerAction()
 
 		qualitySlider.doubleValue = Defaults[.outputQuality]
 		qualitySlider.triggerAction()
+	}
+
+	private func showFpsWarningIfNeeded() {
+		SSApp.runOnce(identifier: "fpsWarning") {
+			delay(seconds: 0.5) {
+				NSAlert.showModal(
+					for: self.view.window,
+					message: "Maximum GIF Frame Rate",
+					informativeText: "Exporting GIFs with a frame rate higher than 50 is not supported as browsers will throttle and play them at 10 FPS."
+				)
+			}
+		}
 	}
 
 	private func setUpWidthAndHeightTextFields() {

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -272,7 +272,7 @@ final class EditVideoViewController: NSViewController {
 			delay(seconds: 0.5) {
 				NSAlert.showModal(
 					for: self.view.window,
-					message: "Maximum GIF Frame Rate",
+					message: "Animated GIF Limitation",
 					informativeText: "Exporting GIFs with a frame rate higher than 50 is not supported as browsers will throttle and play them at 10 FPS."
 				)
 			}

--- a/app-store-description.txt
+++ b/app-store-description.txt
@@ -11,7 +11,7 @@ It converts videos to animated GIFs that use thousands of colors per frame. This
 - Share extension
 - System service
 - Optionally produce smaller lower quality GIFs
-- Generate up to 60 FPS GIFs (for showing off design work on Dribbble)
+- Generate up to 50 FPS GIFs (for showing off design work on Dribbble)
 
 
 ■ To convert, either:
@@ -51,6 +51,10 @@ In the width/height input fields in the editor view, press the arrow up/down key
 ‣ The generated GIFs are huge!
 
 The GIF image format is very space inefficient. It works best with short video clips. Try reducing the dimensions, FPS, or quality.
+
+‣ Why are 60 FPS and higher not supported?
+
+Browsers throttle frame rates above 50 FPS, playing them at 10 FPS.
 
 
 ■ Support

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 	<br>
 </div>
 
-This is a macOS app for the [`gifski` encoder](https://gif.ski), which converts videos to GIF animations using [`pngquant`](https://pngquant.org)'s fancy features for efficient cross-frame palettes and temporal dithering. It produces animated GIFs that use thousands of colors per frame and up to 60 FPS (useful for showing off design work on Dribbble).
+This is a macOS app for the [`gifski` encoder](https://gif.ski), which converts videos to GIF animations using [`pngquant`](https://pngquant.org)'s fancy features for efficient cross-frame palettes and temporal dithering. It produces animated GIFs that use thousands of colors per frame and up to 50 FPS (useful for showing off design work on Dribbble).
 
 You can also produce smaller lower quality GIFs when needed with the “Quality” slider, thanks to [`gifsicle`](https://github.com/kohler/gifsicle).
 
@@ -69,6 +69,10 @@ xcode-select --install
 #### The generated GIFs are huge!
 
 The GIF image format is very space inefficient. It works best with short video clips. Try reducing the dimensions, FPS, or quality.
+
+#### Why are 60 FPS and higher not supported?
+
+Browsers throttle frame rates above 50 FPS, playing them at 10 FPS. [Read more](https://github.com/sindresorhus/Gifski/issues/161#issuecomment-552547771).
 
 #### How can I convert a sequence of PNG images to a GIF?
 


### PR DESCRIPTION
I went with the simple solution of just capping it. I don't see the use of 60 FPS if it doesn't work well in browsers. 50 FPS should be more than enough for GIFs anyway.

It also shows a warning now the first time the user tries to open a video with >50 FPS:

<img width="917" alt="Screen Shot 2020-10-16 at 15 32 31" src="https://user-images.githubusercontent.com/170270/96265162-673da800-0fc5-11eb-9b20-118412621e9a.png">

Fixes #200

---

// @phaseOne