### PR TITLE
Replace "x" in dimensions with multiplication sign

### DIFF
--- a/Gifski/ResizableDimensions.swift
+++ b/Gifski/ResizableDimensions.swift
@@ -17,7 +17,7 @@ struct Dimensions: Equatable, CustomStringConvertible {
 	var description: String {
 		switch type {
 		case .pixels:
-			return String(format: "%.0f x %.0f", value.width, value.height)
+			return String(format: "%.0f × %.0f", value.width, value.height)
 		case .percent:
 			return String(format: "%.0f%%", value.width)
 		}


### PR DESCRIPTION
The actual **×** Unicode symbol makes the values more readable.

> "200 x 200" → "200 × 200"