### PR TITLE
Make older Gifski release clearer in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Gifski supports all the video formats that macOS supports (`.mp4` or `.mov` with
 
 **[Blog post](https://blog.sindresorhus.com/gifski-972692460aa5)** &nbsp;&nbsp; **[Product Hunt](https://www.producthunt.com/posts/gifski-2)**
 
-Requires macOS 10.14 or later.
+Requires macOS 10.14 or later. ([Need older version?](#can-you-support-macos-1013))
 
 ## Download
 

--- a/readme.md
+++ b/readme.md
@@ -21,10 +21,9 @@ Gifski supports all the video formats that macOS supports (`.mp4` or `.mov` with
 
 [![](https://linkmaker.itunes.apple.com/assets/shared/badges/en-us/macappstore-lrg.svg)](https://apps.apple.com/us/app/gifski/id1351639930?mt=12)
 
-The current version is available from the Mac App Store and requires macOS 10.14 or later.
+Requires macOS 10.14 or later.
 
-You can get the last High Sierra compatible version for macOS 10.13 [(Gifski 2.4.0) here](https://github.com/sindresorhus/Gifski/files/3991913/Gifski.2.4.0.-.High.Sierra.zip).
-
+*You can get the last macOS 10.13 compatible version [here](https://github.com/sindresorhus/Gifski/files/3991913/Gifski.2.4.0.-.High.Sierra.zip) (Gifski 2.4.0).*
 
 ## Features
 

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ We don't have any immediate plans to localize the app.
 
 #### Can you support macOS 10.13?
 
-No, but you can get the last compatible version [here](https://github.com/sindresorhus/Gifski/files/3991913/Gifski.2.4.0.-.High.Sierra.zip).
+No, but you can get the last compatible version for High Sierra [(Gifski 2.4.0) here](https://github.com/sindresorhus/Gifski/files/3991913/Gifski.2.4.0.-.High.Sierra.zip).
 
 #### Can you support Windows/Linux?
 

--- a/readme.md
+++ b/readme.md
@@ -17,11 +17,14 @@ Gifski supports all the video formats that macOS supports (`.mp4` or `.mov` with
 
 **[Blog post](https://blog.sindresorhus.com/gifski-972692460aa5)** &nbsp;&nbsp; **[Product Hunt](https://www.producthunt.com/posts/gifski-2)**
 
-Requires macOS 10.14 or later. ([Need older version?](#can-you-support-macos-1013))
-
 ## Download
 
 [![](https://linkmaker.itunes.apple.com/assets/shared/badges/en-us/macappstore-lrg.svg)](https://apps.apple.com/us/app/gifski/id1351639930?mt=12)
+
+The current version is available from the Mac App Store and requires macOS 10.14 or later.
+
+You can get the last High Sierra compatible version for macOS 10.13 [(Gifski 2.4.0) here](https://github.com/sindresorhus/Gifski/files/3991913/Gifski.2.4.0.-.High.Sierra.zip).
+
 
 ## Features
 
@@ -91,10 +94,6 @@ Ensure the images are named in the format `image_000001.png` and adjust the `-fr
 #### Can I contribute localizations?
 
 We don't have any immediate plans to localize the app.
-
-#### Can you support macOS 10.13?
-
-No, but you can get the last compatible version for High Sierra [(Gifski 2.4.0) here](https://github.com/sindresorhus/Gifski/files/3991913/Gifski.2.4.0.-.High.Sierra.zip).
 
 #### Can you support Windows/Linux?
 


### PR DESCRIPTION
Only added a contextual link down to the archive version from system requirements up there just for convenience… +fixed link text a11y