### PR TITLE
Revert e47642ded05c313c96e39e9fe3e324da41fc4ec7

### DIFF
--- a/Gifski/Utilities.swift
+++ b/Gifski/Utilities.swift
@@ -342,12 +342,9 @@ extension AVAssetImageGenerator {
 		var completedCount = 0
 		var decodeFailureFrameCount = 0
 
-		generateCGImagesAsynchronously(forTimes: times) { [weak self] requestedTime, image, actualTime, result, error in
-			guard let self = self else {
-				return
-			}
-
-			if (Double(decodeFailureFrameCount) / Double(totalCount)) > 0.8 {
+		generateCGImagesAsynchronously(forTimes: times) { requestedTime, image, actualTime, result, error in
+			let successFrameCount = totalCount - decodeFailureFrameCount
+			if successFrameCount <= 2 {
 				completionHandler(.failure(NSError.appError("\(decodeFailureFrameCount) of \(totalCount) frames failed to decode. This is a bug in macOS. We are looking into workarounds.")))
 				return
 			}
@@ -378,30 +375,11 @@ extension AVAssetImageGenerator {
 						break
 					}
 
-					// macOS 11 (still an issue in macOS 11.1) started throwing “decode failed” error for some frames in screen recordings. As a workaround, we ignore these. We throw an error if more than 50% of the frames could not be decoded.
+					// macOS 11 (still an issue in macOS 11.2) started throwing “decode failed” error for some frames in screen recordings. As a workaround, we ignore these.
 					if error.code == .decodeFailed {
-						var newActualTime = CMTime.zero
-						if let image = try? self.copyCGImage(at: requestedTime, actualTime: &newActualTime) {
-							completedCount += 1
-
-							completionHandler(
-								.success(
-									CompletionHandlerResult(
-										image: image,
-										requestedTime: requestedTime,
-										actualTime: newActualTime,
-										completedCount: completedCount,
-										totalCount: totalCount,
-										isFinished: completedCount == totalCount
-									)
-								)
-							)
-						} else {
-							decodeFailureFrameCount += 1
-							totalCount -= 1
-							Crashlytics.recordNonFatalError(error: error, userInfo: ["requestedTime": requestedTime.seconds])
-						}
-
+						decodeFailureFrameCount += 1
+						totalCount -= 1
+						Crashlytics.recordNonFatalError(error: error, userInfo: ["requestedTime": requestedTime.seconds])
 						break
 					}
 				}


### PR DESCRIPTION
It, unfortunately, causes the thread to lock up on macOS 11.2 somewhere in the conversion (usually at 8%) and it never continues. For example, with https://github.com/sindresorhus/Gifski/issues/226#issuecomment-773377977

I have a feeling that there is some internal locking going on in AVFoundation and calling both `generateCGImagesAsynchronously` and `copyCGImage` causes it to lock up. I tried putting the `copyCGImage` call in a `DispatchQueue.global().async` and it still locks up.

I think https://github.com/sindresorhus/Gifski/issues/229 is a better solution.