### PR TITLE
Add setting to create bounced (yo-yo) GIFs

### DIFF
--- a/Gifski/Constants.swift
+++ b/Gifski/Constants.swift
@@ -22,4 +22,5 @@ extension Defaults.Keys {
 	static let outputQuality = Key<Double>("outputQuality", default: 1)
 	static let loopGif = Key<Bool>("loopGif", default: true)
 	static let bounceGif = Key<Bool>("bounceGif", default: false)
+	static let suppressKeyframeWarning = Key<Bool>("suppressKeyframeWarning", default: false)
 }

--- a/Gifski/Constants.swift
+++ b/Gifski/Constants.swift
@@ -21,4 +21,5 @@ extension NSColor {
 extension Defaults.Keys {
 	static let outputQuality = Key<Double>("outputQuality", default: 1)
 	static let loopGif = Key<Bool>("loopGif", default: true)
+	static let bounceGif = Key<Bool>("bounceGif", default: false)
 }

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -426,7 +426,13 @@ final class EditVideoViewController: NSViewController {
 		Defaults.observe(.loopGif) { [weak self] in
 			self?.playerViewController.loopPlayback = $0.newValue
 		}
-			.tieToLifetime(of: self)
+		.tieToLifetime(of: self)
+
+		Defaults.observe(.bounceGif) { [weak self] in
+			self?.playerViewController.bouncePlayback = $0.newValue
+			self?.estimateFileSize()
+		}
+		.tieToLifetime(of: self)
 
 		add(childController: playerViewController, to: playerViewWrapper)
 	}

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -73,7 +73,8 @@ final class EditVideoViewController: NSViewController {
 			quality: Defaults[.outputQuality],
 			dimensions: resizableDimensions.changed(dimensionsType: .pixels).currentDimensions.value,
 			frameRate: frameRateSlider.integerValue,
-			loopCount: loopCount
+			loopCount: loopCount,
+			bounce: Defaults[.bounceGif]
 		)
 	}
 

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -42,6 +42,7 @@ final class EditVideoViewController: NSViewController {
 	private var predefinedSizes: [PredefinedSizeItem]!
 	private let formatter = ByteCountFormatter()
 	private var playerViewController: TrimmingAVPlayerViewController!
+	private var playerRateObserver: NSKeyValueObservation?
 
 	private var timeRange: ClosedRange<Double>? { playerViewController?.timeRange }
 
@@ -324,6 +325,68 @@ final class EditVideoViewController: NSViewController {
 		}
 	}
 
+	private func showKeyframeRateWarningIfNeeded() {
+		DispatchQueue.global(qos: .utility).async { [weak self] in
+			guard
+				Defaults[.bounceGif],
+				let asset = self?.asset,
+				let videoTrack = asset.firstVideoTrack,
+				let reader = try? AVAssetReader(asset: asset)
+			else {
+				return
+			}
+
+			let trackReaderOutput = AVAssetReaderTrackOutput(track: videoTrack, outputSettings: nil)
+			reader.add(trackReaderOutput)
+
+			guard reader.startReading() else {
+				return
+			}
+
+			var frameCount: UInt = 0
+			var keyframeCount: UInt = 0
+
+			while true {
+				guard self != nil else {
+					reader.cancelReading()
+					return
+				}
+
+				guard let sampleBuffer = trackReaderOutput.copyNextSampleBuffer() else {
+					reader.cancelReading()
+					break
+				}
+
+				if CMSampleBufferGetNumSamples(sampleBuffer) > 0 {
+					frameCount += 1
+
+					if
+						let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false) as? [NSDictionary],
+						attachments.first?[kCMSampleAttachmentKey_NotSync] == nil
+					{
+						keyframeCount += 1
+					}
+				}
+			}
+
+			let keyframeRate = Double(keyframeCount) / Double(frameCount)
+			if keyframeRate < (1.0 / 30.0) {
+				print("Low keyframe interval \(keyframeRate)")
+
+				DispatchQueue.main.async { [weak self] in
+					if let self = self {
+						NSAlert.showModal(
+							for: self.view.window,
+							title: "Reverse Playback Preview Limitation",
+							message: "Reverse playback may stutter when the video has a low keyframe rate.\nThe GIF will not have the same stutter.",
+							defaultButtonIndex: -1
+						)
+					}
+				}
+			}
+		}
+	}
+
 	private func setUpWidthAndHeightTextFields() {
 		widthTextField.onBlur = { [weak self] width in
 			self?.resizableDimensions.resize(usingWidth: CGFloat(width))
@@ -433,6 +496,14 @@ final class EditVideoViewController: NSViewController {
 			self?.estimateFileSize()
 		}
 		.tieToLifetime(of: self)
+
+		playerRateObserver = playerViewController.playerView.player?.observe(\.rate, options: [.new]) { [weak self] _, change in
+			if change.newValue != 0 {
+				SSApp.runOnce(identifier: "lowKeyframeRateWarning") {
+					self?.showKeyframeRateWarningIfNeeded()
+				}
+			}
+		}
 
 		add(childController: playerViewController, to: playerViewWrapper)
 	}

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -369,9 +369,9 @@ final class EditVideoViewController: NSViewController {
 				}
 			}
 
-			let keyframeRate = Double(keyframeCount) / Double(frameCount)
-			if keyframeRate < (1.0 / 30.0) {
-				print("Low keyframe interval \(keyframeRate)")
+			let keyframeInterval = frameCount / keyframeCount
+			if keyframeInterval > 30 {
+				print("Low keyframe interval \(keyframeInterval)")
 
 				DispatchQueue.main.async { [weak self] in
 					if let self = self {

--- a/Gifski/EditVideoViewController.xib
+++ b/Gifski/EditVideoViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,11 +27,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="805" height="610"/>
+            <rect key="frame" x="0.0" y="0.0" width="805" height="630"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <box title="Trimming" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="O0D-L4-chv">
-                    <rect key="frame" x="21" y="168" width="763" height="414"/>
+                    <rect key="frame" x="21" y="188" width="763" height="414"/>
                     <view key="contentView" id="A4L-BH-n0C">
                         <rect key="frame" x="3" y="3" width="757" height="408"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -52,37 +52,24 @@
                     </view>
                 </box>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="dmb-Gl-vWp">
-                    <rect key="frame" x="24" y="42" width="757" height="122"/>
+                    <rect key="frame" x="24" y="42" width="757" height="142"/>
                     <subviews>
                         <box titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="EGL-as-iA7">
-                            <rect key="frame" x="-3" y="-4" width="391" height="128"/>
+                            <rect key="frame" x="-3" y="-4" width="391" height="148"/>
                             <view key="contentView" id="0XA-H7-N8J">
-                                <rect key="frame" x="3" y="3" width="385" height="122"/>
+                                <rect key="frame" x="3" y="3" width="385" height="142"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CcL-WC-3WC">
-                                        <rect key="frame" x="18" y="88" width="79" height="16"/>
+                                        <rect key="frame" x="18" y="108" width="79" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Dimensions:" id="6Sz-kB-Jau">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="BWw-q9-45K" customClass="MenuPopUpButton" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="99" y="82" width="269" height="25"/>
-                                        <popUpButtonCell key="cell" type="push" title="Custom" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="HdF-GF-uLW" id="SEY-z7-JVq">
-                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="menu"/>
-                                            <menu key="menu" id="hnV-NT-8cV">
-                                                <items>
-                                                    <menuItem title="Custom" state="on" id="HdF-GF-uLW"/>
-                                                    <menuItem isSeparatorItem="YES" id="eN2-yr-NC4"/>
-                                                </items>
-                                            </menu>
-                                        </popUpButtonCell>
-                                    </popUpButton>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Jqk-p7-DIM" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="101" y="50" width="150" height="21"/>
+                                        <rect key="frame" x="101" y="70" width="150" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="150" id="f0p-wK-4JS"/>
                                         </constraints>
@@ -93,7 +80,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="76" translatesAutoresizingMaskIntoConstraints="NO" id="y55-Nm-2MG">
-                                        <rect key="frame" x="18" y="52" width="79" height="16"/>
+                                        <rect key="frame" x="18" y="72" width="79" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Width:" id="lvt-MD-r8L">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -101,7 +88,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bzf-LM-SxO" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="101" y="18" width="150" height="22"/>
+                                        <rect key="frame" x="101" y="38" width="150" height="22"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="150" id="rW2-DE-8b1"/>
                                         </constraints>
@@ -111,8 +98,8 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="76" translatesAutoresizingMaskIntoConstraints="NO" id="iPX-cO-cRP">
-                                        <rect key="frame" x="18" y="21" width="79" height="16"/>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" preferredMaxLayoutWidth="76" translatesAutoresizingMaskIntoConstraints="NO" id="iPX-cO-cRP">
+                                        <rect key="frame" x="18" y="41" width="79" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Height:" id="stb-YD-0DW">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -120,7 +107,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="aVG-zO-Cd7" customClass="MenuPopUpButton" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="263" y="32" width="105" height="25"/>
+                                        <rect key="frame" x="262" y="52" width="107" height="25"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="aVb-nw-wpN"/>
                                         </constraints>
@@ -137,13 +124,26 @@
                                             </menu>
                                         </popUpButtonCell>
                                     </popUpButton>
+                                    <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="BWw-q9-45K" customClass="MenuPopUpButton" customModule="Gifski" customModuleProvider="target">
+                                        <rect key="frame" x="98" y="101" width="271" height="25"/>
+                                        <popUpButtonCell key="cell" type="push" title="Custom" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="HdF-GF-uLW" id="SEY-z7-JVq">
+                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="menu"/>
+                                            <menu key="menu" id="hnV-NT-8cV">
+                                                <items>
+                                                    <menuItem title="Custom" state="on" id="HdF-GF-uLW"/>
+                                                    <menuItem isSeparatorItem="YES" id="eN2-yr-NC4"/>
+                                                </items>
+                                            </menu>
+                                        </popUpButtonCell>
+                                    </popUpButton>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="BWw-q9-45K" secondAttribute="trailing" constant="20" symbolic="YES" id="3lN-kv-suF"/>
                                     <constraint firstItem="iPX-cO-cRP" firstAttribute="centerY" secondItem="bzf-LM-SxO" secondAttribute="centerY" id="3xa-ZO-EKN"/>
                                     <constraint firstItem="Jqk-p7-DIM" firstAttribute="trailing" secondItem="bzf-LM-SxO" secondAttribute="trailing" id="3xb-b3-y9m"/>
                                     <constraint firstAttribute="trailing" secondItem="aVG-zO-Cd7" secondAttribute="trailing" constant="20" symbolic="YES" id="5ui-Il-eRt"/>
-                                    <constraint firstAttribute="bottom" secondItem="bzf-LM-SxO" secondAttribute="bottom" constant="18" id="CPX-cA-dkM"/>
+                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="bzf-LM-SxO" secondAttribute="bottom" constant="18" id="CPX-cA-dkM"/>
                                     <constraint firstItem="Jqk-p7-DIM" firstAttribute="leading" secondItem="y55-Nm-2MG" secondAttribute="trailing" constant="6" id="CVR-y9-8pi"/>
                                     <constraint firstItem="CcL-WC-3WC" firstAttribute="firstBaseline" secondItem="BWw-q9-45K" secondAttribute="firstBaseline" id="Cw7-9r-HGT"/>
                                     <constraint firstItem="iPX-cO-cRP" firstAttribute="firstBaseline" secondItem="bzf-LM-SxO" secondAttribute="firstBaseline" id="E3W-zc-jGw"/>
@@ -165,13 +165,13 @@
                             </view>
                         </box>
                         <box titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="PQ8-dZ-N1k">
-                            <rect key="frame" x="405" y="-4" width="355" height="128"/>
+                            <rect key="frame" x="405" y="-4" width="355" height="148"/>
                             <view key="contentView" id="d7l-jL-VWi">
-                                <rect key="frame" x="3" y="3" width="349" height="122"/>
+                                <rect key="frame" x="3" y="3" width="349" height="142"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iFf-bP-MLi">
-                                        <rect key="frame" x="18" y="54" width="60" height="16"/>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="iFf-bP-MLi">
+                                        <rect key="frame" x="18" y="74" width="60" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Quality:" id="K0X-2I-A0y">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -179,18 +179,18 @@
                                         </textFieldCell>
                                     </textField>
                                     <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wmm-UU-g6g">
-                                        <rect key="frame" x="82" y="52" width="218" height="19"/>
+                                        <rect key="frame" x="82" y="65" width="218" height="28"/>
                                         <sliderCell key="cell" continuous="YES" alignment="left" minValue="0.5" maxValue="1" doubleValue="0.50459439766839376" tickMarkPosition="above" sliderType="linear" id="EO3-Q8-SDC"/>
                                     </slider>
                                     <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rej-Dl-z8Y">
-                                        <rect key="frame" x="82" y="86" width="218" height="19"/>
+                                        <rect key="frame" x="82" y="99" width="218" height="28"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="214" id="BIw-L9-Hls"/>
                                         </constraints>
                                         <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="5" maxValue="30" doubleValue="30" tickMarkPosition="above" sliderType="linear" id="aU8-ka-YW2"/>
                                     </slider>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="5Ke-gz-J2u" customClass="MonospacedLabel" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="304" y="88" width="27" height="16"/>
+                                        <rect key="frame" x="304" y="108" width="27" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="23" id="Pld-9q-pDl"/>
                                         </constraints>
@@ -200,8 +200,8 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="Fxs-GY-NUz">
-                                        <rect key="frame" x="18" y="88" width="60" height="16"/>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="751" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="Fxs-GY-NUz">
+                                        <rect key="frame" x="18" y="108" width="60" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="FPS:" id="O3d-Ep-9VJ">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -209,7 +209,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="taC-H3-jcv" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="84" y="18" width="70" height="21"/>
+                                        <rect key="frame" x="84" y="38" width="70" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="70" id="5HI-Ct-v80"/>
                                         </constraints>
@@ -220,7 +220,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VFJ-xS-F2B">
-                                        <rect key="frame" x="18" y="20" width="60" height="16"/>
+                                        <rect key="frame" x="18" y="40" width="60" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="56" id="jKq-aA-DK5"/>
                                         </constraints>
@@ -231,7 +231,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Mk2-3o-6CT">
-                                        <rect key="frame" x="197" y="19" width="102" height="18"/>
+                                        <rect key="frame" x="197" y="39" width="106" height="18"/>
                                         <buttonCell key="cell" type="check" title="Loop Forever" bezelStyle="regularSquare" imagePosition="left" inset="2" id="c3l-oV-Y0b">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -246,9 +246,25 @@
                                         </connections>
                                     </button>
                                     <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="x03-mN-zhh">
-                                        <rect key="frame" x="159" y="14" width="19" height="28"/>
+                                        <rect key="frame" x="159" y="34" width="19" height="28"/>
                                         <stepperCell key="cell" continuous="YES" alignment="left" maxValue="100" id="d96-4O-hec"/>
                                     </stepper>
+                                    <button verticalHuggingPriority="750" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="6Zb-wc-GCx">
+                                        <rect key="frame" x="197" y="17" width="72" height="18"/>
+                                        <string key="toolTip">When enabled the GIFs will playback normally then playback in reverse. Resulting in a GIF that is double the length and double the filesize.</string>
+                                        <buttonCell key="cell" type="check" title="Bounce" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Pn4-Io-BK6">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <binding destination="YjB-2D-chi" name="value" keyPath="values.bounceGif" id="bqu-Cy-vFj">
+                                                <dictionary key="options">
+                                                    <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                    <integer key="NSNullPlaceholder" value="1"/>
+                                                </dictionary>
+                                            </binding>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="5Ke-gz-J2u" secondAttribute="trailing" constant="20" symbolic="YES" id="2kR-fz-ftG"/>
@@ -262,6 +278,8 @@
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="leading" secondItem="d7l-jL-VWi" secondAttribute="leading" constant="20" symbolic="YES" id="LrM-Ia-FKl"/>
                                     <constraint firstItem="x03-mN-zhh" firstAttribute="leading" secondItem="taC-H3-jcv" secondAttribute="trailing" constant="8" id="Nwi-6N-osH"/>
                                     <constraint firstItem="Rej-Dl-z8Y" firstAttribute="trailing" secondItem="wmm-UU-g6g" secondAttribute="trailing" id="PvJ-zU-xzT"/>
+                                    <constraint firstAttribute="bottom" secondItem="6Zb-wc-GCx" secondAttribute="bottom" constant="18" id="Q5E-UB-XQ6"/>
+                                    <constraint firstItem="Mk2-3o-6CT" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="d7l-jL-VWi" secondAttribute="trailing" constant="20" symbolic="YES" id="RYd-mg-49e"/>
                                     <constraint firstItem="Mk2-3o-6CT" firstAttribute="leading" secondItem="x03-mN-zhh" secondAttribute="trailing" constant="24" id="Sul-hb-FPM"/>
                                     <constraint firstItem="Mk2-3o-6CT" firstAttribute="centerY" secondItem="VFJ-xS-F2B" secondAttribute="centerY" id="XYH-yM-mxX"/>
                                     <constraint firstItem="5Ke-gz-J2u" firstAttribute="firstBaseline" secondItem="Fxs-GY-NUz" secondAttribute="firstBaseline" id="YcA-vG-aBS"/>
@@ -270,8 +288,11 @@
                                     <constraint firstItem="Rej-Dl-z8Y" firstAttribute="leading" secondItem="Fxs-GY-NUz" secondAttribute="trailing" constant="8" symbolic="YES" id="er2-bc-7th"/>
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="top" secondItem="d7l-jL-VWi" secondAttribute="top" constant="18" id="ivK-Jk-HzZ"/>
                                     <constraint firstItem="taC-H3-jcv" firstAttribute="leading" secondItem="VFJ-xS-F2B" secondAttribute="trailing" constant="8" symbolic="YES" id="kfm-tz-40e"/>
+                                    <constraint firstItem="6Zb-wc-GCx" firstAttribute="top" secondItem="Mk2-3o-6CT" secondAttribute="bottom" constant="6" symbolic="YES" id="s9V-zs-69T"/>
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="firstBaseline" secondItem="Rej-Dl-z8Y" secondAttribute="firstBaseline" id="tLB-lC-RNe"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6Zb-wc-GCx" secondAttribute="trailing" constant="20" symbolic="YES" id="ugv-UM-F1Q"/>
                                     <constraint firstItem="taC-H3-jcv" firstAttribute="centerY" secondItem="VFJ-xS-F2B" secondAttribute="centerY" id="wvf-lf-XjK"/>
+                                    <constraint firstItem="6Zb-wc-GCx" firstAttribute="leading" secondItem="Mk2-3o-6CT" secondAttribute="leading" id="zh8-pM-ByA"/>
                                 </constraints>
                             </view>
                         </box>
@@ -287,10 +308,10 @@
                     </constraints>
                 </customView>
                 <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hHF-zN-Wqa">
-                    <rect key="frame" x="627" y="10" width="154" height="22"/>
+                    <rect key="frame" x="643" y="10" width="138" height="22"/>
                     <subviews>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AF4-ry-iae">
-                            <rect key="frame" x="-6" y="-6" width="82" height="32"/>
+                            <rect key="frame" x="-7" y="-5" width="76" height="32"/>
                             <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ZWE-2a-d8e">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -300,7 +321,7 @@
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="coA-lD-jim">
-                            <rect key="frame" x="71" y="-6" width="89" height="32"/>
+                            <rect key="frame" x="62" y="-5" width="83" height="32"/>
                             <buttonCell key="cell" type="push" title="Convert" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gbn-c3-6oW">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -323,7 +344,7 @@ DQ
                     </customSpacing>
                 </stackView>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iCr-ZN-9aI">
-                    <rect key="frame" x="22" y="14" width="122" height="16"/>
+                    <rect key="frame" x="22" y="15" width="122" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Estimated File Size:" id="s0a-Dg-FJd">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>

--- a/Gifski/EditVideoViewController.xib
+++ b/Gifski/EditVideoViewController.xib
@@ -251,7 +251,7 @@
                                     </stepper>
                                     <button verticalHuggingPriority="750" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="6Zb-wc-GCx">
                                         <rect key="frame" x="197" y="17" width="72" height="18"/>
-                                        <string key="toolTip">When enabled the GIFs will playback normally then playback in reverse. Resulting in a GIF that is double the length and double the filesize.</string>
+                                        <string key="toolTip">Makes the GIF play normally and then in reverse, resulting in a GIF that is double the length and double the file size.</string>
                                         <buttonCell key="cell" type="check" title="Bounce" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Pn4-Io-BK6">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>

--- a/Gifski/TrimmingAVPlayerViewController.swift
+++ b/Gifski/TrimmingAVPlayerViewController.swift
@@ -4,7 +4,7 @@ import AVKit
 final class TrimmingAVPlayerViewController: NSViewController {
 	private(set) var timeRange: ClosedRange<Double>?
 	private let playerItem: AVPlayerItem
-	private let player: AVPlayer
+	private let player: LoopingPlayer
 	private let controlsStyle: AVPlayerViewControlsStyle
 	private let timeRangeDidChange: ((ClosedRange<Double>) -> Void)?
 
@@ -26,13 +26,22 @@ final class TrimmingAVPlayerViewController: NSViewController {
 		}
 	}
 
+	var bouncePlayback: Bool {
+		get {
+			player.bouncePlayback
+		}
+		set {
+			player.bouncePlayback = newValue
+		}
+	}
+
 	init(
 		playerItem: AVPlayerItem,
 		controlsStyle: AVPlayerViewControlsStyle = .inline,
 		timeRangeDidChange: ((ClosedRange<Double>) -> Void)? = nil
 	) {
 		self.playerItem = playerItem
-		self.player = AVPlayer(playerItem: playerItem)
+		self.player = LoopingPlayer(playerItem: playerItem)
 		self.controlsStyle = controlsStyle
 		self.timeRangeDidChange = timeRangeDidChange
 		super.init(nibName: nil, bundle: nil)

--- a/Gifski/Utilities.swift
+++ b/Gifski/Utilities.swift
@@ -3345,6 +3345,23 @@ extension AVPlayer {
 			toleranceAfter: .zero
 		)
 	}
+
+	/**
+	Seek to the end of the playable range of the video.
+
+	The start might not be at `duration` if, for example, the video has been trimmed in `AVPlayerView` trim mode.
+	*/
+	func seekToEnd() {
+		guard let seconds = currentItem?.playbackRange?.upperBound ?? currentItem?.duration.seconds else {
+			return
+		}
+
+		seek(
+			to: CMTime(seconds: seconds, preferredTimescale: .video),
+			toleranceBefore: .zero,
+			toleranceAfter: .zero
+		)
+	}
 }
 
 
@@ -3375,8 +3392,11 @@ final class LoopingPlayer: AVPlayer {
 				NotificationCenter.default.removeObserver(observationToken)
 				self.observationToken = nil
 			}
+			actionAtItemEnd = .pause
 			return
 		}
+
+		actionAtItemEnd = .none
 
 		guard observationToken == nil else {
 			// Already observing, no need to update
@@ -3390,8 +3410,11 @@ final class LoopingPlayer: AVPlayer {
 			}
 
 			if self.bouncePlayback, self.currentItem?.canPlayReverse == true, (self.currentTime().seconds > self.currentItem?.playbackRange?.lowerBound ?? 0) {
+				self.pause()
+				self.seekToEnd()
 				self.rate = -1
 			} else if self.loopPlayback {
+				self.pause()
 				self.seekToStart()
 				self.rate = 1
 			}

--- a/Gifski/Utilities.swift
+++ b/Gifski/Utilities.swift
@@ -3409,12 +3409,12 @@ final class LoopingPlayer: AVPlayer {
 				return
 			}
 
+			self.pause()
+
 			if self.bouncePlayback, self.currentItem?.canPlayReverse == true, (self.currentTime().seconds > self.currentItem?.playbackRange?.lowerBound ?? 0) {
-				self.pause()
 				self.seekToEnd()
 				self.rate = -1
 			} else if self.loopPlayback {
-				self.pause()
 				self.seekToStart()
 				self.rate = 1
 			}

--- a/app-store-description.txt
+++ b/app-store-description.txt
@@ -7,6 +7,7 @@ It converts videos to animated GIFs that use thousands of colors per frame. This
 
 - Video trimming
 - Precise control of dimensions
+- Control over GIF looping and bouncing (yo-yo) playback
 - Copy, share, or drag the GIF
 - Share extension
 - System service
@@ -33,6 +34,11 @@ You can share a macOS screen recording with Gifski by clicking on the thumbnail 
 ■ System service
 
 Gifski includes a system service that lets you quickly convert a video to GIF from the “Services” menu in any app that provides a compatible video file.
+
+
+■ Bounce (yo-yo) GIF playback
+
+Gifski includes the option to create GIFs that bounce back and forth between forward and backward playback. This option doubles the number of frames in the GIF so the file size will double as well.
 
 
 ■ Tips

--- a/app-store-keywords.txt
+++ b/app-store-keywords.txt
@@ -1,1 +1,1 @@
-gif,video,movie,image,convert,converter,mp4,mov,photo,picture,photography,resize,design
+gif,video,movie,image,convert,converter,mp4,mov,photo,picture,photography,resize,design,bounce,yoyo

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,10 @@ Gifski includes a share extension that lets you share videos to Gifski. Just sel
 
 Gifski includes a [system service](https://www.computerworld.com/article/2476298/os-x-a-quick-guide-to-services-on-your-mac.html) that lets you quickly convert a video to GIF from the **Services** menu in any app that provides a compatible video file.
 
+### Bounce (yo-yo) GIF playback
+
+Gifski includes the option to create GIFs that bounce back and forth between forward and backward playback. This is a similar effect to the bounce effect in [iOS's Live Photo effects](https://support.apple.com/en-us/HT207310). This option doubles the number of frames in the GIF so the file size will double as well.
+
 ## Tips
 
 #### Quickly copy or save the GIF


### PR DESCRIPTION
Adds support for creating bounced gifs. Bouncing a GIF appends the reversed sequence of frames to the end of the forward playing frames

The option is shown as a new checkbox next to the loop checkbox
![editor](https://user-images.githubusercontent.com/915431/115346975-b37cc700-a165-11eb-9537-fb4d0e17e138.png)

The editor previews the bouncing (when enabled)
![editor playback](https://user-images.githubusercontent.com/915431/115346213-be832780-a164-11eb-9c09-cfbb34d2b63c.gif)

Issue #234 calls this "back-and-forth" or "yo-yo". I used "bounce" since that's what the iOS Photos app uses (screenshot below), but I'm fine with renaming the checkbox whatever you prefer
![ios](https://user-images.githubusercontent.com/915431/115346241-c773f900-a164-11eb-9530-9f6884bedafd.gif)

Builds upon PR #238
Closes #234