### PR TITLE
Use NSViewController.present() with custom animator #108

### DIFF
--- a/Gifski/App.swift
+++ b/Gifski/App.swift
@@ -8,8 +8,6 @@ import DockProgress
 final class AppDelegate: NSObject, NSApplicationDelegate {
 	lazy var mainWindowController = MainWindowController()
 
-	var previousEditViewController: EditVideoViewController?
-
 	// Possible workaround for crashing bug because of Crashlytics swizzling.
 	let notificationCenter = UNUserNotificationCenter.current()
 

--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -70,6 +70,7 @@ final class ConversionCompletedViewController: NSViewController {
 				return
 			}
 
+			// Prevents a rare situation where the this closure is invoked after user has clicked back or dropped a new video file
 			guard self.view.window?.contentViewController == self else {
 				return
 			}

--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -70,6 +70,10 @@ final class ConversionCompletedViewController: NSViewController {
 				return
 			}
 
+			guard self.view.window?.contentViewController == self else {
+				return
+			}
+
 			self.tooltip.show(from: self.draggableFile, preferredEdge: .maxY)
 		}
 
@@ -192,10 +196,7 @@ final class ConversionCompletedViewController: NSViewController {
 
 	@IBAction
 	private func backButton(_ sender: NSButton) {
-		// It's safe to force-unwrap as there's no scenario where it will be nil.
-		let viewController = AppDelegate.shared.previousEditViewController!
-		viewController.isConverting = false
-		push(viewController: viewController)
+		presentingViewController?.presentingViewController?.dismiss(self)
 	}
 }
 

--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -70,7 +70,8 @@ final class ConversionCompletedViewController: NSViewController {
 				return
 			}
 
-			// Prevents a rare situation where the this closure is invoked after user has clicked back or dropped a new video file
+			// Prevents the following tooltip code from failing in a rare situation where
+			// this closure is invoked after user has clicked back or dropped a new video file
 			guard self.view.window?.contentViewController == self else {
 				return
 			}

--- a/Gifski/ConversionViewController.swift
+++ b/Gifski/ConversionViewController.swift
@@ -57,7 +57,9 @@ final class ConversionViewController: NSViewController {
 
 	/// Gets called when the Esc key is pressed.
 	override func cancelOperation(_ sender: Any?) {
-		cancelConversion()
+		if isRunning {
+			cancelConversion()
+		}
 	}
 
 	private func start(conversion: Gifski.Conversion) {
@@ -116,12 +118,8 @@ final class ConversionViewController: NSViewController {
 			progress?.cancel()
 		}
 
-		stopConversion { [weak self] in
-			// It's safe to force-unwrap as there's no scenario where it will be nil.
-			let viewController = AppDelegate.shared.previousEditViewController!
-			viewController.isConverting = false
-
-			self?.push(viewController: viewController)
+		stopConversion { [self] in
+			self.presentingViewController?.dismiss(self)
 		}
 	}
 

--- a/Gifski/ConversionViewController.swift
+++ b/Gifski/ConversionViewController.swift
@@ -118,8 +118,8 @@ final class ConversionViewController: NSViewController {
 			progress?.cancel()
 		}
 
-		stopConversion { [self] in
-			self.presentingViewController?.dismiss(self)
+		stopConversion { [weak self] in
+			self?.pop()
 		}
 	}
 

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -90,8 +90,6 @@ final class EditVideoViewController: NSViewController {
 		self.inputUrl = inputUrl
 		self.asset = asset
 		self.videoMetadata = videoMetadata
-
-		AppDelegate.shared.previousEditViewController = self
 	}
 
 	var isConverting = false
@@ -108,9 +106,7 @@ final class EditVideoViewController: NSViewController {
 
 	@IBAction
 	private func cancel(_ sender: Any) {
-		let videoDropController = VideoDropViewController()
-		push(viewController: videoDropController)
-		AppDelegate.shared.previousEditViewController = nil
+		presentingViewController?.dismiss(self)
 	}
 
 	override func viewDidLoad() {
@@ -125,6 +121,10 @@ final class EditVideoViewController: NSViewController {
 		setUpLoopCountControls()
 		setUpDropView()
 		setUpTrimmingView()
+	}
+
+	override func viewWillAppear() {
+		isConverting = false
 	}
 
 	override func viewDidAppear() {

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -106,7 +106,7 @@ final class EditVideoViewController: NSViewController {
 
 	@IBAction
 	private func cancel(_ sender: Any) {
-		presentingViewController?.dismiss(self)
+		pop()
 	}
 
 	override func viewDidLoad() {

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -124,7 +124,7 @@ final class MainWindowController: NSWindowController {
 			return
 		}
 
-		rootVideoDropViewController.popAll {
+		rootVideoDropViewController.popToRootViewController(animated: false) {
 			let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
 			self.rootVideoDropViewController.push(viewController: editController)
 		}

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -2,6 +2,8 @@ import Cocoa
 
 final class MainWindowController: NSWindowController {
 	private let videoValidator = VideoValidator()
+	
+	public let rootVideoDropViewController = VideoDropViewController();
 
 	var isConverting: Bool {
 		window?.contentViewController is ConversionViewController
@@ -58,9 +60,10 @@ final class MainWindowController: NSWindowController {
 
 	convenience init() {
 		let window = NSWindow.centeredWindow(size: .zero)
-		window.contentViewController = VideoDropViewController()
 		window.centerNatural()
 		self.init(window: window)
+
+		window.contentViewController = rootVideoDropViewController
 
 		with(window) {
 			$0.delegate = self
@@ -121,8 +124,10 @@ final class MainWindowController: NSWindowController {
 			return
 		}
 
-		let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
-		window?.contentViewController?.push(viewController: editController)
+		rootVideoDropViewController.popAll {
+			let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
+			self.rootVideoDropViewController.push(viewController: editController)
+		}
 	}
 }
 

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -124,9 +124,9 @@ final class MainWindowController: NSWindowController {
 			return
 		}
 
-		rootVideoDropViewController.popToRootViewController {
+		rootVideoDropViewController.popToRootViewController { [weak self] in
 			let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
-			self.rootVideoDropViewController.push(viewController: editController)
+			self?.rootVideoDropViewController.push(viewController: editController)
 		}
 	}
 }

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -2,8 +2,8 @@ import Cocoa
 
 final class MainWindowController: NSWindowController {
 	private let videoValidator = VideoValidator()
-	
-	public let rootVideoDropViewController = VideoDropViewController();
+
+	let rootVideoDropViewController = VideoDropViewController()
 
 	var isConverting: Bool {
 		window?.contentViewController is ConversionViewController
@@ -124,7 +124,7 @@ final class MainWindowController: NSWindowController {
 			return
 		}
 
-		rootVideoDropViewController.popToRootViewController(animated: false) {
+		rootVideoDropViewController.popToRootViewController {
 			let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
 			self.rootVideoDropViewController.push(viewController: editController)
 		}

--- a/Gifski/Utilities.swift
+++ b/Gifski/Utilities.swift
@@ -3028,7 +3028,7 @@ final class ViewControllerPresentationAnimator: NSObject, NSViewControllerPresen
 	}
 }
 
-private func showViewControllerOnWindow(_ viewController: NSViewController, window: NSWindow, completion: (() -> Void)? = nil) {
+private func showViewControllerOnWindow(_ viewController: NSViewController, window: NSWindow, animated: Bool = true, completion: (() -> Void)? = nil) {
 	// Workaround for macOS first responder quirk. Still in macOS 10.15.3.
 	// Reproduce: Without the below, if you click convert, hide the window, show the window when the conversion is done, and then drag and drop a new file, the width/height text fields are now not editable.
 	window.makeFirstResponder(viewController)
@@ -3036,7 +3036,7 @@ private func showViewControllerOnWindow(_ viewController: NSViewController, wind
 	let newOrigin = CGPoint(x: window.frame.midX - viewController.view.frame.width / 2.0, y: window.frame.midY - viewController.view.frame.height / 2.0)
 	let newFrame = CGRect(origin: newOrigin, size: viewController.view.frame.size)
 
-	guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else {
+	if animated == false || NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
 		DispatchQueue.main.async {
 			window.contentViewController = nil
 			window.setFrame(newFrame, display: true)
@@ -3065,14 +3065,14 @@ extension NSViewController {
 		present(viewController, animator: animator)
 	}
 
-	func popAll(completion: (() -> Void)? = nil) {
+	func popToRootViewController(animated: Bool = true, completion: (() -> Void)? = nil) {
 		guard let window = view.window else {
 			return
 		}
 		guard let rootVC = (window.windowController as? MainWindowController)?.rootVideoDropViewController else {
 			return
 		}
-		showViewControllerOnWindow(rootVC, window: window, completion: completion)
+		showViewControllerOnWindow(rootVC, window: window, animated: animated, completion: completion)
 	}
 
 	func add(childController: NSViewController) {

--- a/Gifski/Utilities.swift
+++ b/Gifski/Utilities.swift
@@ -3064,6 +3064,10 @@ extension NSViewController {
 		let animator = ViewControllerPresentationAnimator(completion: completion)
 		present(viewController, animator: animator)
 	}
+	
+	func pop() {
+		presentingViewController?.dismiss(self)
+	}
 
 	func popToRootViewController(animated: Bool = true, completion: (() -> Void)? = nil) {
 		guard let window = view.window else {

--- a/Gifski/VideoDropViewController.swift
+++ b/Gifski/VideoDropViewController.swift
@@ -60,7 +60,7 @@ final class VideoDropViewController: NSViewController {
 			return
 		}
 
-		popAll {
+		popToRootViewController(animated: false) {
 			let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
 			rootVideoDropViewController.push(viewController: editController)
 		}

--- a/Gifski/VideoDropViewController.swift
+++ b/Gifski/VideoDropViewController.swift
@@ -60,7 +60,7 @@ final class VideoDropViewController: NSViewController {
 			return
 		}
 
-		popToRootViewController(animated: false) {
+		popToRootViewController {
 			let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
 			rootVideoDropViewController.push(viewController: editController)
 		}

--- a/Gifski/VideoDropViewController.swift
+++ b/Gifski/VideoDropViewController.swift
@@ -56,7 +56,13 @@ final class VideoDropViewController: NSViewController {
 			return
 		}
 
-		let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
-		push(viewController: editController)
+		guard let rootVideoDropViewController = (view.window?.windowController as? MainWindowController)?.rootVideoDropViewController else {
+			return
+		}
+
+		popAll {
+			let editController = EditVideoViewController(inputUrl: inputUrl, asset: asset, videoMetadata: videoMetadata)
+			rootVideoDropViewController.push(viewController: editController)
+		}
 	}
 }


### PR DESCRIPTION
While this still changes the contentViewController, presenting view controllers behave exactly like a stack. Works flawlessly (in my testing) with dismiss:

Fixes #108


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#108: Use `NSViewController.present()` with custom animator](https://issuehunt.io/repos/119822304/issues/108)
---
</details>
<!-- /Issuehunt content-->