### PR TITLE
Add support for changing the speed

### DIFF
--- a/Gifski/App.swift
+++ b/Gifski/App.swift
@@ -37,6 +37,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 		// Set launch completions option if the notification center could not be set up already.
 		LaunchCompletions.applicationDidLaunch()
+
+//		#if DEBUG
+//		mainWindowController.convert(URL(fileURLWithPath: "/Users/sindresorhus/Library/Containers/com.sindresorhus.Gifski/Data/Library/Application Support/com.sindresorhus.Gifski/Fixture.mp4"))
+//		#endif
 	}
 
 	/// Returns `nil` if it should not continue.

--- a/Gifski/Constants.swift
+++ b/Gifski/Constants.swift
@@ -4,7 +4,7 @@ import Defaults
 enum Constants {
 	static let defaultWindowSize = CGSize(width: 360, height: 240)
 	static let backgroundImage = NSImage(named: "BackgroundImage")!
-	static let allowedFrameRate = 5.0...50.0
+	static let allowedFrameRate = 3.0...50.0
 	static let loopCountRange = 0...100
 }
 
@@ -20,6 +20,7 @@ extension NSColor {
 
 extension Defaults.Keys {
 	static let outputQuality = Key<Double>("outputQuality", default: 1)
+	static let outputSpeed = Key<Double>("outputSpeed", default: 1)
 	static let loopGif = Key<Bool>("loopGif", default: true)
 	static let bounceGif = Key<Bool>("bounceGif", default: false)
 	static let suppressKeyframeWarning = Key<Bool>("suppressKeyframeWarning", default: false)

--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -41,7 +41,7 @@ final class ConversionCompletedViewController: NSViewController {
 		if !NSApp.isActive || view.window?.isVisible == false {
 			let notification = UNMutableNotificationContent()
 			notification.title = "Conversion Completed"
-			notification.subtitle = conversion.video.filename
+			notification.subtitle = conversion.sourceURL.filename
 			let request = UNNotificationRequest(identifier: "conversionCompleted", content: notification, trigger: nil)
 			// UNUserNotificationCenter.current().add(request)
 			AppDelegate.shared.notificationCenter.add(request)
@@ -154,7 +154,7 @@ final class ConversionCompletedViewController: NSViewController {
 	}
 
 	private func saveGif() {
-		let inputUrl = conversion.video
+		let inputUrl = conversion.sourceURL
 
 		let panel = NSSavePanel()
 		panel.canCreateDirectories = true

--- a/Gifski/ConversionViewController.swift
+++ b/Gifski/ConversionViewController.swift
@@ -83,7 +83,7 @@ final class ConversionViewController: NSViewController {
 
 			gifski.run(conversion, isEstimation: false) { result in
 				do {
-					let gifUrl = try self.generateTemporaryGifUrl(for: conversion.video)
+					let gifUrl = try self.generateTemporaryGifUrl(for: conversion.sourceURL)
 					try result.get().write(to: gifUrl, options: .atomic)
 					try? gifUrl.setMetadata(key: .itemCreator, value: "\(SSApp.name) \(SSApp.version)")
 					self.didComplete(conversion: conversion, gifUrl: gifUrl)

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -336,18 +336,22 @@ final class EditVideoViewController: NSViewController {
 			showFpsWarningIfNeeded()
 		}
 
-		updateFrameRateSlider()
+		updateFrameRateSlider(isInit: true)
 
 		qualitySlider.doubleValue = Defaults[.outputQuality]
 		qualitySlider.triggerAction()
 	}
 
-	private func updateFrameRateSlider() {
+	private func updateFrameRateSlider(isInit: Bool) {
 		// We round it so that `29.970` becomes `30` for practical reasons.
 		let frameRate = (videoMetadata.frameRate * Defaults[.outputSpeed]).rounded()
 
 		frameRateSlider.maxValue = frameRate.clamped(to: Constants.allowedFrameRate)
-		frameRateSlider.doubleValue = defaultFrameRate(inputFrameRate: frameRate)
+
+		if isInit {
+			frameRateSlider.doubleValue = defaultFrameRate(inputFrameRate: frameRate)
+		}
+
 		frameRateSlider.triggerAction()
 	}
 
@@ -511,7 +515,7 @@ final class EditVideoViewController: NSViewController {
 				self.modifiedAsset = self.asset?.firstVideoTrack?.extractToNewAssetAndChangeSpeed(to: $0.newValue)
 				self.playerViewController.currentItem = AVPlayerItem(asset: self.modifiedAsset)
 				self.estimatedFileSizeModel.updateEstimate()
-				self.updateFrameRateSlider()
+				self.updateFrameRateSlider(isInit: false)
 			}
 			.store(in: &cancellables)
 

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -10,6 +10,7 @@ struct SpeedView: View {
 		HStack(alignment: .firstTextBaseline) {
 			Text("Speed:")
 			Slider(value: $outputSpeed, in: 0.5...5, step: 0.5)
+				.offset(y: OS.isMacOS11OrLater ? 0 : -4)
 			Text("\(outputSpeed.formatted)×")
 				.font(.system().monospacedDigit()) // TODO: Use `.monospacedDigit()` view modifier when targeting macOS 12.
 				.frame(width: 30, alignment: .leading)

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -344,7 +344,7 @@ final class EditVideoViewController: NSViewController {
 
 	private func updateFrameRateSlider() {
 		// We round it so that `29.970` becomes `30` for practical reasons.
-		let frameRate = (videoMetadata.frameRate / Defaults[.outputSpeed]).rounded()
+		let frameRate = (videoMetadata.frameRate * Defaults[.outputSpeed]).rounded()
 
 		frameRateSlider.maxValue = frameRate.clamped(to: Constants.allowedFrameRate)
 		frameRateSlider.doubleValue = defaultFrameRate(inputFrameRate: frameRate)

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -95,7 +95,8 @@ final class EditVideoViewController: NSViewController {
 
 	private var conversionSettings: Gifski.Conversion {
 		.init(
-			video: inputUrl,
+			asset: modifiedAsset,
+			sourceURL: inputUrl,
 			timeRange: timeRange,
 			quality: Defaults[.outputQuality],
 			dimensions: resizableDimensions.changed(dimensionsType: .pixels).currentDimensions.value,

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -336,12 +336,19 @@ final class EditVideoViewController: NSViewController {
 			showFpsWarningIfNeeded()
 		}
 
-		frameRateSlider.maxValue = frameRate.clamped(to: Constants.allowedFrameRate)
-		frameRateSlider.doubleValue = defaultFrameRate(inputFrameRate: frameRate)
-		frameRateSlider.triggerAction()
+		updateFrameRateSlider()
 
 		qualitySlider.doubleValue = Defaults[.outputQuality]
 		qualitySlider.triggerAction()
+	}
+
+	private func updateFrameRateSlider() {
+		// We round it so that `29.970` becomes `30` for practical reasons.
+		let frameRate = (videoMetadata.frameRate / Defaults[.outputSpeed]).rounded()
+
+		frameRateSlider.maxValue = frameRate.clamped(to: Constants.allowedFrameRate)
+		frameRateSlider.doubleValue = defaultFrameRate(inputFrameRate: frameRate)
+		frameRateSlider.triggerAction()
 	}
 
 	private func showFpsWarningIfNeeded() {
@@ -504,6 +511,7 @@ final class EditVideoViewController: NSViewController {
 				self.modifiedAsset = self.asset?.firstVideoTrack?.extractToNewAssetAndChangeSpeed(to: $0.newValue)
 				self.playerViewController.currentItem = AVPlayerItem(asset: self.modifiedAsset)
 				self.estimatedFileSizeModel.updateEstimate()
+				self.updateFrameRateSlider()
 			}
 			.store(in: &cancellables)
 

--- a/Gifski/EditVideoViewController.swift
+++ b/Gifski/EditVideoViewController.swift
@@ -10,7 +10,7 @@ struct SpeedView: View {
 		HStack(alignment: .firstTextBaseline) {
 			Text("Speed:")
 			Slider(value: $outputSpeed, in: 0.5...5, step: 0.5)
-			Text("\(outputSpeed.formatted)x")
+			Text("\(outputSpeed.formatted)×")
 				.font(.system().monospacedDigit()) // TODO: Use `.monospacedDigit()` view modifier when targeting macOS 12.
 				.frame(width: 30, alignment: .leading)
 		}

--- a/Gifski/EditVideoViewController.xib
+++ b/Gifski/EditVideoViewController.xib
@@ -20,6 +20,7 @@
                 <outlet property="playerViewWrapper" destination="64m-0V-WWu" id="6cd-p2-aMe"/>
                 <outlet property="predefinedSizesDropdown" destination="BWw-q9-45K" id="mLx-BM-G3f"/>
                 <outlet property="qualitySlider" destination="wmm-UU-g6g" id="RlB-Ty-dIN"/>
+                <outlet property="speedView" destination="Jqs-Co-IF8" id="cem-73-urC"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
                 <outlet property="widthTextField" destination="Jqk-p7-DIM" id="uiL-Sw-PE5"/>
             </connections>
@@ -27,17 +28,17 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="805" height="630"/>
+            <rect key="frame" x="0.0" y="0.0" width="805" height="650"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <box title="Trimming" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="O0D-L4-chv">
-                    <rect key="frame" x="21" y="188" width="763" height="414"/>
+                    <rect key="frame" x="26" y="208" width="754" height="414"/>
                     <view key="contentView" id="A4L-BH-n0C">
-                        <rect key="frame" x="3" y="3" width="757" height="408"/>
+                        <rect key="frame" x="3" y="3" width="748" height="408"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="64m-0V-WWu">
-                                <rect key="frame" x="4" y="4" width="749" height="400"/>
+                                <rect key="frame" x="4" y="4" width="740" height="400"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="400" id="u0s-Fn-zEv"/>
                                 </constraints>
@@ -52,24 +53,45 @@
                     </view>
                 </box>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="dmb-Gl-vWp">
-                    <rect key="frame" x="24" y="42" width="757" height="142"/>
+                    <rect key="frame" x="29" y="40" width="748" height="164"/>
                     <subviews>
                         <box titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="EGL-as-iA7">
-                            <rect key="frame" x="-3" y="-4" width="391" height="148"/>
+                            <rect key="frame" x="-3" y="-4" width="391" height="170"/>
                             <view key="contentView" id="0XA-H7-N8J">
-                                <rect key="frame" x="3" y="3" width="385" height="142"/>
+                                <rect key="frame" x="3" y="3" width="385" height="164"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CcL-WC-3WC">
-                                        <rect key="frame" x="18" y="108" width="79" height="16"/>
+                                        <rect key="frame" x="18" y="130" width="79" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Dimensions:" id="6Sz-kB-Jau">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
+                                    <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="BWw-q9-45K" customClass="MenuPopUpButton" customModule="Gifski" customModuleProvider="target">
+                                        <rect key="frame" x="98" y="123" width="271" height="25"/>
+                                        <popUpButtonCell key="cell" type="push" title="Custom" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="HdF-GF-uLW" id="SEY-z7-JVq">
+                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="menu"/>
+                                            <menu key="menu" id="hnV-NT-8cV">
+                                                <items>
+                                                    <menuItem title="Custom" state="on" id="HdF-GF-uLW"/>
+                                                    <menuItem isSeparatorItem="YES" id="eN2-yr-NC4"/>
+                                                </items>
+                                            </menu>
+                                        </popUpButtonCell>
+                                    </popUpButton>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="76" translatesAutoresizingMaskIntoConstraints="NO" id="y55-Nm-2MG">
+                                        <rect key="frame" x="18" y="94" width="79" height="16"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Width:" id="lvt-MD-r8L">
+                                            <font key="font" usesAppearanceFont="YES"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Jqk-p7-DIM" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="101" y="70" width="150" height="21"/>
+                                        <rect key="frame" x="101" y="92" width="150" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="150" id="f0p-wK-4JS"/>
                                         </constraints>
@@ -79,16 +101,16 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="76" translatesAutoresizingMaskIntoConstraints="NO" id="y55-Nm-2MG">
-                                        <rect key="frame" x="18" y="72" width="79" height="16"/>
-                                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Width:" id="lvt-MD-r8L">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" preferredMaxLayoutWidth="76" translatesAutoresizingMaskIntoConstraints="NO" id="iPX-cO-cRP">
+                                        <rect key="frame" x="18" y="63" width="79" height="16"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Height:" id="stb-YD-0DW">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bzf-LM-SxO" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="101" y="38" width="150" height="22"/>
+                                        <rect key="frame" x="101" y="60" width="150" height="22"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="150" id="rW2-DE-8b1"/>
                                         </constraints>
@@ -98,16 +120,8 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" preferredMaxLayoutWidth="76" translatesAutoresizingMaskIntoConstraints="NO" id="iPX-cO-cRP">
-                                        <rect key="frame" x="18" y="41" width="79" height="16"/>
-                                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Height:" id="stb-YD-0DW">
-                                            <font key="font" usesAppearanceFont="YES"/>
-                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                    </textField>
                                     <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="aVG-zO-Cd7" customClass="MenuPopUpButton" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="262" y="52" width="107" height="25"/>
+                                        <rect key="frame" x="262" y="74" width="107" height="25"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="aVb-nw-wpN"/>
                                         </constraints>
@@ -124,19 +138,9 @@
                                             </menu>
                                         </popUpButtonCell>
                                     </popUpButton>
-                                    <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="BWw-q9-45K" customClass="MenuPopUpButton" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="98" y="101" width="271" height="25"/>
-                                        <popUpButtonCell key="cell" type="push" title="Custom" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="HdF-GF-uLW" id="SEY-z7-JVq">
-                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="menu"/>
-                                            <menu key="menu" id="hnV-NT-8cV">
-                                                <items>
-                                                    <menuItem title="Custom" state="on" id="HdF-GF-uLW"/>
-                                                    <menuItem isSeparatorItem="YES" id="eN2-yr-NC4"/>
-                                                </items>
-                                            </menu>
-                                        </popUpButtonCell>
-                                    </popUpButton>
+                                    <customView autoresizesSubviews="NO" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Jqs-Co-IF8">
+                                        <rect key="frame" x="0.0" y="0.0" width="385" height="48"/>
+                                    </customView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="BWw-q9-45K" secondAttribute="trailing" constant="20" symbolic="YES" id="3lN-kv-suF"/>
@@ -149,6 +153,7 @@
                                     <constraint firstItem="iPX-cO-cRP" firstAttribute="firstBaseline" secondItem="bzf-LM-SxO" secondAttribute="firstBaseline" id="E3W-zc-jGw"/>
                                     <constraint firstItem="CcL-WC-3WC" firstAttribute="leading" secondItem="0XA-H7-N8J" secondAttribute="leading" constant="20" symbolic="YES" id="HhJ-ce-3ee"/>
                                     <constraint firstItem="bzf-LM-SxO" firstAttribute="top" secondItem="Jqk-p7-DIM" secondAttribute="bottom" constant="10" symbolic="YES" id="N6v-k0-zlP"/>
+                                    <constraint firstItem="Jqs-Co-IF8" firstAttribute="top" secondItem="iPX-cO-cRP" secondAttribute="bottom" constant="15" id="Ooh-UE-N5D"/>
                                     <constraint firstItem="BWw-q9-45K" firstAttribute="leading" secondItem="CcL-WC-3WC" secondAttribute="trailing" constant="6" id="R0b-U1-LBo"/>
                                     <constraint firstItem="Jqk-p7-DIM" firstAttribute="leading" secondItem="bzf-LM-SxO" secondAttribute="leading" id="SVW-md-lm4"/>
                                     <constraint firstItem="Jqk-p7-DIM" firstAttribute="baseline" secondItem="y55-Nm-2MG" secondAttribute="firstBaseline" id="TTZ-o3-8xL"/>
@@ -156,6 +161,7 @@
                                     <constraint firstItem="y55-Nm-2MG" firstAttribute="trailing" secondItem="iPX-cO-cRP" secondAttribute="trailing" id="Zu3-j5-Ky1"/>
                                     <constraint firstItem="Jqk-p7-DIM" firstAttribute="top" secondItem="BWw-q9-45K" secondAttribute="bottom" constant="14" id="cMA-4k-YyZ"/>
                                     <constraint firstItem="CcL-WC-3WC" firstAttribute="top" secondItem="0XA-H7-N8J" secondAttribute="top" constant="18" id="e21-Jw-Cpg"/>
+                                    <constraint firstAttribute="bottom" secondItem="Jqs-Co-IF8" secondAttribute="bottom" id="erp-FG-Zgo"/>
                                     <constraint firstItem="CcL-WC-3WC" firstAttribute="trailing" secondItem="y55-Nm-2MG" secondAttribute="trailing" id="gZ6-eG-Td7"/>
                                     <constraint firstItem="aVG-zO-Cd7" firstAttribute="leading" secondItem="Jqk-p7-DIM" secondAttribute="trailing" constant="14" id="hFA-Ht-idc"/>
                                     <constraint firstItem="CcL-WC-3WC" firstAttribute="leading" secondItem="y55-Nm-2MG" secondAttribute="leading" id="jjc-8P-Qlj"/>
@@ -163,34 +169,31 @@
                                     <constraint firstItem="y55-Nm-2MG" firstAttribute="baseline" secondItem="Jqk-p7-DIM" secondAttribute="firstBaseline" id="td1-Ld-kdX"/>
                                 </constraints>
                             </view>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="Jqs-Co-IF8" secondAttribute="trailing" id="Xj1-Ji-D1r"/>
+                                <constraint firstItem="Jqs-Co-IF8" firstAttribute="leading" secondItem="EGL-as-iA7" secondAttribute="leading" id="uoX-8I-4ov"/>
+                            </constraints>
                         </box>
                         <box titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="PQ8-dZ-N1k">
-                            <rect key="frame" x="405" y="-4" width="355" height="148"/>
+                            <rect key="frame" x="405" y="-4" width="346" height="170"/>
                             <view key="contentView" id="d7l-jL-VWi">
-                                <rect key="frame" x="3" y="3" width="349" height="142"/>
+                                <rect key="frame" x="3" y="3" width="340" height="164"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="iFf-bP-MLi">
-                                        <rect key="frame" x="18" y="74" width="60" height="16"/>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Quality:" id="K0X-2I-A0y">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="751" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="Fxs-GY-NUz">
+                                        <rect key="frame" x="18" y="130" width="51" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="FPS:" id="O3d-Ep-9VJ">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
                                     <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wmm-UU-g6g">
-                                        <rect key="frame" x="82" y="65" width="218" height="28"/>
+                                        <rect key="frame" x="73" y="87" width="218" height="28"/>
                                         <sliderCell key="cell" continuous="YES" alignment="left" minValue="0.5" maxValue="1" doubleValue="0.50459439766839376" tickMarkPosition="above" sliderType="linear" id="EO3-Q8-SDC"/>
                                     </slider>
-                                    <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rej-Dl-z8Y">
-                                        <rect key="frame" x="82" y="99" width="218" height="28"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="214" id="BIw-L9-Hls"/>
-                                        </constraints>
-                                        <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="5" maxValue="30" doubleValue="30" tickMarkPosition="above" sliderType="linear" id="aU8-ka-YW2"/>
-                                    </slider>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="5Ke-gz-J2u" customClass="MonospacedLabel" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="304" y="108" width="27" height="16"/>
+                                        <rect key="frame" x="295" y="130" width="27" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="23" id="Pld-9q-pDl"/>
                                         </constraints>
@@ -200,27 +203,23 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="751" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="Fxs-GY-NUz">
-                                        <rect key="frame" x="18" y="108" width="60" height="16"/>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="FPS:" id="O3d-Ep-9VJ">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="iFf-bP-MLi">
+                                        <rect key="frame" x="18" y="96" width="51" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Quality:" id="K0X-2I-A0y">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="taC-H3-jcv" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="84" y="38" width="70" height="21"/>
+                                    <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rej-Dl-z8Y">
+                                        <rect key="frame" x="73" y="121" width="218" height="28"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="70" id="5HI-Ct-v80"/>
+                                            <constraint firstAttribute="width" constant="214" id="BIw-L9-Hls"/>
                                         </constraints>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" title="0" drawsBackground="YES" id="bLQ-hB-2aY">
-                                            <font key="font" usesAppearanceFont="YES"/>
-                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                    </textField>
+                                        <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="5" maxValue="30" doubleValue="30" tickMarkPosition="above" sliderType="linear" id="aU8-ka-YW2"/>
+                                    </slider>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VFJ-xS-F2B">
-                                        <rect key="frame" x="18" y="40" width="60" height="16"/>
+                                        <rect key="frame" x="18" y="62" width="60" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="56" id="jKq-aA-DK5"/>
                                         </constraints>
@@ -230,8 +229,23 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
+                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="taC-H3-jcv" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
+                                        <rect key="frame" x="84" y="60" width="70" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="70" id="5HI-Ct-v80"/>
+                                        </constraints>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" title="0" drawsBackground="YES" id="bLQ-hB-2aY">
+                                            <font key="font" usesAppearanceFont="YES"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="x03-mN-zhh">
+                                        <rect key="frame" x="159" y="56" width="19" height="28"/>
+                                        <stepperCell key="cell" continuous="YES" alignment="left" maxValue="100" id="d96-4O-hec"/>
+                                    </stepper>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Mk2-3o-6CT">
-                                        <rect key="frame" x="197" y="39" width="106" height="18"/>
+                                        <rect key="frame" x="197" y="61" width="106" height="18"/>
                                         <buttonCell key="cell" type="check" title="Loop Forever" bezelStyle="regularSquare" imagePosition="left" inset="2" id="c3l-oV-Y0b">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -245,12 +259,8 @@
                                             </binding>
                                         </connections>
                                     </button>
-                                    <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="x03-mN-zhh">
-                                        <rect key="frame" x="159" y="34" width="19" height="28"/>
-                                        <stepperCell key="cell" continuous="YES" alignment="left" maxValue="100" id="d96-4O-hec"/>
-                                    </stepper>
                                     <button toolTip="Makes the GIF play normally and then in reverse, resulting in a GIF that is double the length and double the file size." verticalHuggingPriority="750" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="6Zb-wc-GCx">
-                                        <rect key="frame" x="197" y="17" width="72" height="18"/>
+                                        <rect key="frame" x="197" y="39" width="72" height="18"/>
                                         <buttonCell key="cell" type="check" title="Bounce" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Pn4-Io-BK6">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -277,7 +287,7 @@
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="leading" secondItem="d7l-jL-VWi" secondAttribute="leading" constant="20" symbolic="YES" id="LrM-Ia-FKl"/>
                                     <constraint firstItem="x03-mN-zhh" firstAttribute="leading" secondItem="taC-H3-jcv" secondAttribute="trailing" constant="8" id="Nwi-6N-osH"/>
                                     <constraint firstItem="Rej-Dl-z8Y" firstAttribute="trailing" secondItem="wmm-UU-g6g" secondAttribute="trailing" id="PvJ-zU-xzT"/>
-                                    <constraint firstAttribute="bottom" secondItem="6Zb-wc-GCx" secondAttribute="bottom" constant="18" id="Q5E-UB-XQ6"/>
+                                    <constraint firstAttribute="bottom" secondItem="6Zb-wc-GCx" secondAttribute="bottom" constant="40" id="Q5E-UB-XQ6"/>
                                     <constraint firstItem="Mk2-3o-6CT" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="d7l-jL-VWi" secondAttribute="trailing" constant="20" symbolic="YES" id="RYd-mg-49e"/>
                                     <constraint firstItem="Mk2-3o-6CT" firstAttribute="leading" secondItem="x03-mN-zhh" secondAttribute="trailing" constant="24" id="Sul-hb-FPM"/>
                                     <constraint firstItem="Mk2-3o-6CT" firstAttribute="centerY" secondItem="VFJ-xS-F2B" secondAttribute="centerY" id="XYH-yM-mxX"/>
@@ -307,10 +317,10 @@
                     </constraints>
                 </customView>
                 <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hHF-zN-Wqa">
-                    <rect key="frame" x="643" y="10" width="138" height="22"/>
+                    <rect key="frame" x="639" y="10" width="138" height="20"/>
                     <subviews>
                         <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AF4-ry-iae">
-                            <rect key="frame" x="-7" y="-5" width="76" height="32"/>
+                            <rect key="frame" x="-7" y="-7" width="76" height="32"/>
                             <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ZWE-2a-d8e">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -320,7 +330,7 @@
                             </connections>
                         </button>
                         <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="coA-lD-jim">
-                            <rect key="frame" x="62" y="-5" width="83" height="32"/>
+                            <rect key="frame" x="62" y="-7" width="83" height="32"/>
                             <buttonCell key="cell" type="push" title="Convert" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gbn-c3-6oW">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -343,21 +353,19 @@ DQ
                     </customSpacing>
                 </stackView>
                 <customView autoresizesSubviews="NO" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Khl-D6-Nlh">
-                    <rect key="frame" x="24" y="10" width="599" height="24"/>
+                    <rect key="frame" x="29" y="10" width="590" height="22"/>
                 </customView>
             </subviews>
             <constraints>
-                <constraint firstItem="O0D-L4-chv" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="30" id="0c5-JS-PUZ"/>
                 <constraint firstItem="Khl-D6-Nlh" firstAttribute="top" secondItem="dmb-Gl-vWp" secondAttribute="bottom" constant="8" symbolic="YES" id="3VS-cf-Vfz"/>
                 <constraint firstItem="hHF-zN-Wqa" firstAttribute="leading" secondItem="Khl-D6-Nlh" secondAttribute="trailing" priority="250" constant="20" id="8T0-ep-vxC"/>
                 <constraint firstItem="Khl-D6-Nlh" firstAttribute="bottom" secondItem="hHF-zN-Wqa" secondAttribute="bottom" id="Dvd-ZR-Aeh"/>
                 <constraint firstItem="hHF-zN-Wqa" firstAttribute="top" secondItem="dmb-Gl-vWp" secondAttribute="bottom" constant="10" id="Ik7-TN-Ier"/>
                 <constraint firstItem="Khl-D6-Nlh" firstAttribute="leading" secondItem="dmb-Gl-vWp" secondAttribute="leading" id="N1j-1o-AqA"/>
+                <constraint firstItem="O0D-L4-chv" firstAttribute="centerX" secondItem="Hz6-mo-xeY" secondAttribute="centerX" id="OtD-aL-U92"/>
                 <constraint firstItem="hHF-zN-Wqa" firstAttribute="trailing" secondItem="PQ8-dZ-N1k" secondAttribute="trailing" id="YKH-2e-sJa"/>
-                <constraint firstAttribute="trailing" secondItem="dmb-Gl-vWp" secondAttribute="trailing" constant="24" id="dQw-6m-2yr"/>
-                <constraint firstAttribute="bottom" secondItem="hHF-zN-Wqa" secondAttribute="bottom" constant="10" id="hjJ-IT-g7h"/>
                 <constraint firstItem="dmb-Gl-vWp" firstAttribute="top" secondItem="O0D-L4-chv" secondAttribute="bottom" constant="8" id="i6Z-EW-yj5"/>
-                <constraint firstItem="dmb-Gl-vWp" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="24" id="pvh-s2-rgz"/>
+                <constraint firstItem="O0D-L4-chv" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="30" id="nsq-ev-wnG"/>
                 <constraint firstItem="O0D-L4-chv" firstAttribute="trailing" secondItem="dmb-Gl-vWp" secondAttribute="trailing" id="rSm-mQ-HZm"/>
                 <constraint firstItem="O0D-L4-chv" firstAttribute="leading" secondItem="dmb-Gl-vWp" secondAttribute="leading" id="sNI-Gg-Rs0"/>
             </constraints>

--- a/Gifski/EditVideoViewController.xib
+++ b/Gifski/EditVideoViewController.xib
@@ -216,7 +216,7 @@
                                         <constraints>
                                             <constraint firstAttribute="width" constant="214" id="BIw-L9-Hls"/>
                                         </constraints>
-                                        <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="5" maxValue="30" doubleValue="30" tickMarkPosition="above" sliderType="linear" id="aU8-ka-YW2"/>
+                                        <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="3" maxValue="50" doubleValue="30" tickMarkPosition="above" sliderType="linear" id="aU8-ka-YW2"/>
                                     </slider>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VFJ-xS-F2B">
                                         <rect key="frame" x="9" y="62" width="60" height="16"/>

--- a/Gifski/EditVideoViewController.xib
+++ b/Gifski/EditVideoViewController.xib
@@ -219,7 +219,7 @@
                                         <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="5" maxValue="30" doubleValue="30" tickMarkPosition="above" sliderType="linear" id="aU8-ka-YW2"/>
                                     </slider>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VFJ-xS-F2B">
-                                        <rect key="frame" x="18" y="62" width="60" height="16"/>
+                                        <rect key="frame" x="9" y="62" width="60" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="56" id="jKq-aA-DK5"/>
                                         </constraints>
@@ -230,7 +230,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="taC-H3-jcv" customClass="IntTextField" customModule="Gifski" customModuleProvider="target">
-                                        <rect key="frame" x="84" y="60" width="70" height="21"/>
+                                        <rect key="frame" x="75" y="60" width="70" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="70" id="5HI-Ct-v80"/>
                                         </constraints>
@@ -241,11 +241,11 @@
                                         </textFieldCell>
                                     </textField>
                                     <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="x03-mN-zhh">
-                                        <rect key="frame" x="159" y="56" width="19" height="28"/>
+                                        <rect key="frame" x="150" y="56" width="19" height="28"/>
                                         <stepperCell key="cell" continuous="YES" alignment="left" maxValue="100" id="d96-4O-hec"/>
                                     </stepper>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Mk2-3o-6CT">
-                                        <rect key="frame" x="197" y="61" width="106" height="18"/>
+                                        <rect key="frame" x="188" y="61" width="106" height="18"/>
                                         <buttonCell key="cell" type="check" title="Loop Forever" bezelStyle="regularSquare" imagePosition="left" inset="2" id="c3l-oV-Y0b">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -260,7 +260,7 @@
                                         </connections>
                                     </button>
                                     <button toolTip="Makes the GIF play normally and then in reverse, resulting in a GIF that is double the length and double the file size." verticalHuggingPriority="750" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="6Zb-wc-GCx">
-                                        <rect key="frame" x="197" y="39" width="72" height="18"/>
+                                        <rect key="frame" x="188" y="39" width="72" height="18"/>
                                         <buttonCell key="cell" type="check" title="Bounce" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Pn4-Io-BK6">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -279,6 +279,7 @@
                                     <constraint firstAttribute="trailing" secondItem="5Ke-gz-J2u" secondAttribute="trailing" constant="20" symbolic="YES" id="2kR-fz-ftG"/>
                                     <constraint firstItem="x03-mN-zhh" firstAttribute="centerY" secondItem="VFJ-xS-F2B" secondAttribute="centerY" id="47z-Zg-it9"/>
                                     <constraint firstItem="Rej-Dl-z8Y" firstAttribute="leading" secondItem="wmm-UU-g6g" secondAttribute="leading" id="5gr-Y1-Ixw"/>
+                                    <constraint firstItem="VFJ-xS-F2B" firstAttribute="trailing" secondItem="iFf-bP-MLi" secondAttribute="trailing" id="7s3-Xe-fhD"/>
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="leading" secondItem="iFf-bP-MLi" secondAttribute="leading" id="AOu-eR-uC7"/>
                                     <constraint firstItem="iFf-bP-MLi" firstAttribute="top" secondItem="Fxs-GY-NUz" secondAttribute="bottom" constant="18" id="BdX-Ip-Sfw"/>
                                     <constraint firstItem="VFJ-xS-F2B" firstAttribute="top" secondItem="iFf-bP-MLi" secondAttribute="bottom" constant="18" id="GaU-PP-u4b"/>
@@ -292,7 +293,6 @@
                                     <constraint firstItem="Mk2-3o-6CT" firstAttribute="leading" secondItem="x03-mN-zhh" secondAttribute="trailing" constant="24" id="Sul-hb-FPM"/>
                                     <constraint firstItem="Mk2-3o-6CT" firstAttribute="centerY" secondItem="VFJ-xS-F2B" secondAttribute="centerY" id="XYH-yM-mxX"/>
                                     <constraint firstItem="5Ke-gz-J2u" firstAttribute="firstBaseline" secondItem="Fxs-GY-NUz" secondAttribute="firstBaseline" id="YcA-vG-aBS"/>
-                                    <constraint firstItem="VFJ-xS-F2B" firstAttribute="leading" secondItem="iFf-bP-MLi" secondAttribute="leading" id="eAS-rc-ZTd"/>
                                     <constraint firstItem="5Ke-gz-J2u" firstAttribute="leading" secondItem="Rej-Dl-z8Y" secondAttribute="trailing" constant="8" symbolic="YES" id="eXk-Bv-HWg"/>
                                     <constraint firstItem="Rej-Dl-z8Y" firstAttribute="leading" secondItem="Fxs-GY-NUz" secondAttribute="trailing" constant="8" symbolic="YES" id="er2-bc-7th"/>
                                     <constraint firstItem="Fxs-GY-NUz" firstAttribute="top" secondItem="d7l-jL-VWi" secondAttribute="top" constant="18" id="ivK-Jk-HzZ"/>

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -1,7 +1,6 @@
 import Foundation
 import AVFoundation
 import FirebaseCrashlytics
-import Defaults
 
 private var conversionCount = 0
 
@@ -41,7 +40,8 @@ final class Gifski {
 	- Parameter bounce: Whether output should bounce or not.
 	*/
 	struct Conversion {
-		let video: URL
+		let asset: AVAsset
+		let sourceURL: URL
 		var timeRange: ClosedRange<Double>?
 		var quality: Double = 1
 		var dimensions: CGSize?
@@ -234,17 +234,7 @@ final class Gifski {
 		for conversion: Conversion,
 		jobKey: String
 	) -> Result<(generator: AVAssetImageGenerator, times: [CMTime], fps: Int), Error> {
-		// TODO: We should be passing around `AVAsset` instead of loading it again here.
-		var asset: AVAsset = AVURLAsset(
-			url: conversion.video,
-			options: [
-				AVURLAssetPreferPreciseDurationAndTimingKey: true
-			]
-		)
-
-		if let newAsset = asset.firstVideoTrack?.extractToNewAssetAndChangeSpeed(to: Defaults[.outputSpeed]) {
-			asset = newAsset
-		}
+		let asset = conversion.asset
 
 		record(
 			jobKey: jobKey,
@@ -294,32 +284,26 @@ final class Gifski {
 
 		let generator = AVAssetImageGenerator(asset: asset)
 		generator.appliesPreferredTrackTransform = true
+		generator.requestedTimeToleranceBefore = .zero
+		generator.requestedTimeToleranceAfter = .zero
 
 		// This improves the performance a little bit.
 		if let dimensions = conversion.dimensions {
 			generator.maximumSize = CGSize(widthHeight: dimensions.longestSide)
 		}
 
-		// Even though we enforce a minimum of 5 FPS in the GUI, a source video could have lower FPS, and we should allow that.
+		// Even though we enforce a minimum of 3 FPS in the GUI, a source video could have lower FPS, and we should allow that.
 		var fps = (conversion.frameRate.map { Double($0) } ?? assetFrameRate).clamped(to: 0.1...Constants.allowedFrameRate.upperBound)
 		fps = min(fps, assetFrameRate)
 
 		print("FPS:", fps)
 
-		// `.zero` tolerance is much slower and fails a lot on macOS 11. (macOS 11.1)
-		if #available(macOS 11, *) {
-			let tolerance = CMTime(seconds: 0.5 / fps, preferredTimescale: .video)
-			generator.requestedTimeToleranceBefore = tolerance
-			generator.requestedTimeToleranceAfter = tolerance
-		} else {
-			generator.requestedTimeToleranceBefore = .zero
-			generator.requestedTimeToleranceAfter = .zero
-		}
-
+		// TODO: Instead of calculating what part of the video to get, we could just trim the actual `AVAssetTrack`.
 		let videoRange = conversion.timeRange?.clamped(to: videoTrackRange) ?? videoTrackRange
 		let startTime = videoRange.lowerBound
 		let duration = videoRange.length
 		let frameCount = Int(duration * fps)
+		let timescale = firstVideoTrack.naturalTimeScale
 
 		guard frameCount >= 2 else {
 			return .failure(.notEnoughFrames(frameCount))
@@ -328,7 +312,6 @@ final class Gifski {
 		print("Frame count:", frameCount)
 
 		let frameStep = 1 / fps
-		let timescale = asset.duration.timescale
 		var frameForTimes: [CMTime] = (0..<frameCount).map { index in
 			let presentationTimestamp = startTime + (frameStep * Double(index))
 			return CMTime(
@@ -338,7 +321,7 @@ final class Gifski {
 		}
 
 		// Ensure we include the last frame. For example, the above might have calculated `[..., 6.25, 6.3]`, but the duration is `6.3647`, so we might miss the last frame if it appears for a short time.
-		frameForTimes.append(asset.duration)
+		frameForTimes.append(CMTime(seconds: duration, preferredTimescale: timescale))
 
 		record(
 			jobKey: jobKey,
@@ -448,7 +431,7 @@ final class Gifski {
 					let actualReverseTimestamp = max(0, expectedReverseTimestamp + timestampSlippage.seconds)
 
 					try gifski?.addFrame(
-						pixelFormat: .argb,
+						pixelFormat: .rgba,
 						frameNumber: reverseFrameNumber,
 						width: pixels.width,
 						height: pixels.height,

--- a/Gifski/TrimmingAVPlayerViewController.swift
+++ b/Gifski/TrimmingAVPlayerViewController.swift
@@ -36,7 +36,7 @@ final class TrimmingAVPlayerViewController: NSViewController {
 	/**
 	Get or set the current player item.
 
-	When setting an item, it preserves the current playback rate (which means pause state too) and playback position.
+	When setting an item, it preserves the current playback rate (which means pause state too), playback position, and trim range.
 	*/
 	var currentItem: AVPlayerItem {
 		get { player.currentItem! }

--- a/Gifski/Utilities.swift
+++ b/Gifski/Utilities.swift
@@ -4528,3 +4528,53 @@ extension AVPlayerItem {
 		}
 	}
 }
+
+
+enum OperatingSystem {
+	case macOS
+	case iOS
+	case tvOS
+	case watchOS
+
+	#if os(macOS)
+	static let current = macOS
+	#elseif os(iOS)
+	static let current = iOS
+	#elseif os(tvOS)
+	static let current = tvOS
+	#elseif os(watchOS)
+	static let current = watchOS
+	#else
+	#error("Unsupported platform")
+	#endif
+}
+
+extension OperatingSystem {
+	/// - Note: Only use this when you cannot use an `if #available` check. For example, inline in function calls.
+	static let isMacOS12OrLater: Bool = {
+		#if os(macOS)
+		if #available(macOS 12, *) {
+			return true
+		} else {
+			return false
+		}
+		#else
+		return false
+		#endif
+	}()
+
+	/// - Note: Only use this when you cannot use an `if #available` check. For example, inline in function calls.
+	static let isMacOS11OrLater: Bool = {
+		#if os(macOS)
+		if #available(macOS 11, *) {
+			return true
+		} else {
+			return false
+		}
+		#else
+		return false
+		#endif
+	}()
+}
+
+typealias OS = OperatingSystem

--- a/app-store-description.txt
+++ b/app-store-description.txt
@@ -8,6 +8,7 @@ It converts videos to animated GIFs that use thousands of colors per frame. This
 - Video trimming
 - Precise control of dimensions
 - Control over GIF looping and bouncing (yo-yo) playback
+- Adjust the speed
 - Copy, share, or drag the GIF
 - Share extension
 - System service

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ You can also produce smaller lower quality GIFs when needed with the â€œQualityâ
 
 Gifski supports all the video formats that macOS supports (`.mp4` or `.mov` with H264, HEVC, ProRes, etc). The [QuickTime Animation format](https://en.wikipedia.org/wiki/QuickTime_Animation) is not supported. Use [ProRes 4444 XQ](https://en.wikipedia.org/wiki/Apple_ProRes) instead. It's more efficient, more widely supported, and like QuickTime Animation, it also supports alpha channel.
 
+Gifski has a bunch of settings like changing dimensions, speed, frame rate, quality, looping, and more.
+
 **[Blog post](https://blog.sindresorhus.com/gifski-972692460aa5)** &nbsp;&nbsp; **[Product Hunt](https://www.producthunt.com/posts/gifski-2)**
 
 ## Download


### PR DESCRIPTION
This was way more complicated than I had anticipated. Apparently, the API for playing videos only supports speeds of 0.5x to 2x (as usual, not documented) (https://github.com/feedback-assistant/reports/issues/229), so I had to employ a different tactic. Because of this, there's a small visual glitch when changing the speed because we're actually replacing the video with a copy. I have not found a way around that yet.

**Test build: [Gifski.app.zip](https://github.com/sindresorhus/Gifski/files/7003281/Gifski.app.zip)**

Fixes #201

---

This also fixes most of the problems with `generateCGImagesAsynchronously` (decode errors). Turns out the fix we had for https://github.com/sindresorhus/Gifski/blob/d8875c8aff216c34ac8380c0f627e4037c686575/Gifski/VideoValidator.swift#L174 was not actually used in the export as we read the video file in again when exporting: https://github.com/sindresorhus/Gifski/blob/d8875c8aff216c34ac8380c0f627e4037c686575/Gifski/Gifski.swift#L236 Duuh.

---

This also fixes #247 

https://github.com/sindresorhus/Gifski/pull/248/files#diff-c96c1241ad689fb7ba3363fb54bd27e6573310535d39eebdb597ce9838f3849dR340-R341

---

<img width="917" alt="Screen Shot 2021-07-15 at 01 02 46" src="https://user-images.githubusercontent.com/170270/125704126-62b94cae-c807-4f98-9b7b-6a5f929d8146.png">
