### PR TITLE
Add an "open" button to the conversion completed screen

### DIFF
--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -11,6 +11,7 @@ final class ConversionCompletedViewController: NSViewController {
 	@IBOutlet private var saveAsButton: NSButton!
 	@IBOutlet private var shareButton: NSButton!
 	@IBOutlet private var copyButton: NSButton!
+	@IBOutlet private var openButton: NSButton!
 	@IBOutlet private var wrapperView: NSView!
 
 	private let draggableFile = DraggableFile()
@@ -90,6 +91,12 @@ final class ConversionCompletedViewController: NSViewController {
 		draggableFileWrapper.wantsLayer = true
 		draggableFileWrapper.layer?.masksToBounds = false
 		draggableFile.constrainEdgesToSuperview()
+
+		if #available(macOS 11, *) {
+			openButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "Open")
+		} else {
+			openButton.title = "+"
+		}
 	}
 
 	private func setUp() {
@@ -197,11 +204,16 @@ final class ConversionCompletedViewController: NSViewController {
 	}
 
 	@IBAction
-	private func backButton(_ sender: NSButton) {
+	private func backButtonAction(_ sender: NSButton) {
 		// It's safe to force-unwrap as there's no scenario where it will be nil.
 		let viewController = AppDelegate.shared.previousEditViewController!
 		viewController.isConverting = false
 		push(viewController: viewController)
+	}
+
+	@IBAction
+	private func openButtonAction(_ sender: NSButton) {
+		AppDelegate.shared.mainWindowController.presentOpenPanel()
 	}
 }
 

--- a/Gifski/ConversionCompletedViewController.swift
+++ b/Gifski/ConversionCompletedViewController.swift
@@ -93,9 +93,17 @@ final class ConversionCompletedViewController: NSViewController {
 		draggableFile.constrainEdgesToSuperview()
 
 		if #available(macOS 11, *) {
-			openButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "Open")
+			// TODO: Find a better icon for this.
+			openButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "New conversion")
+
+			SSApp.runOnce(identifier: "showOpenButtonLabel") {
+				openButton.imagePosition = .imageLeading
+				openButton.title = "Open"
+				openButton.sizeToFit()
+				openButton.frame.x -= 34
+			}
 		} else {
-			openButton.title = "+"
+			openButton.isHidden = true
 		}
 	}
 

--- a/Gifski/ConversionCompletedViewController.xib
+++ b/Gifski/ConversionCompletedViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +12,7 @@
                 <outlet property="draggableFileWrapper" destination="9j4-tJ-yJo" id="VRB-Jv-ZNr"/>
                 <outlet property="fileNameLabel" destination="uI2-zc-34L" id="pQ3-AY-w92"/>
                 <outlet property="fileSizeLabel" destination="gf3-Uh-Jor" id="jQq-RK-lGs"/>
+                <outlet property="openButton" destination="ok2-9s-P9c" id="Q63-57-fiB"/>
                 <outlet property="saveAsButton" destination="Olx-b9-5Qw" id="LNI-8U-pVi"/>
                 <outlet property="shareButton" destination="xNp-Z5-9zb" id="hqI-fr-pgX"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
@@ -98,7 +99,18 @@
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
                             <connections>
-                                <action selector="backButton:" target="-2" id="rTe-95-NTz"/>
+                                <action selector="backButtonAction:" target="-2" id="KlW-Xf-vgD"/>
+                            </connections>
+                        </button>
+                        <button toolTip="Open" verticalHuggingPriority="750" id="ok2-9s-P9c">
+                            <rect key="frame" x="301" y="188" width="30" height="23"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="only" alignment="center" borderStyle="border" inset="2" id="zL6-Ix-hy5">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="openButtonAction:" target="-2" id="SHI-f1-5sW"/>
                             </connections>
                         </button>
                     </subviews>

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -64,6 +64,7 @@ final class MainWindowController: NSWindowController {
 		panel.canCreateDirectories = false
 		// TODO: Use `.allowedContentTypes` here when targeting macOS 11.
 		panel.allowedFileTypes = Device.supportedVideoTypes
+		panel.message = "Choose a MP4 or MOV video to convert to an animated GIF"
 
 		panel.beginSheetModal(for: window!) { [weak self] in
 			guard


### PR DESCRIPTION
To make it faster to convert another file, for people not using drag & drop. Clicking it, will present the system "open" panel.

I'm open to suggestions for a more fitting symbol (SF Symbols) than a `+`.

<img width="472" alt="Screen Shot 2021-09-26 at 16 44 11" src="https://user-images.githubusercontent.com/170270/134802558-77832edb-f587-4e62-8b21-e4b0f8c7d52c.png">


