### PR TITLE
Skip incorrect out-of-range frames

### DIFF
--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -396,6 +396,9 @@ final class Gifski {
 				)
 			}
 			
+			// TODO: This is just a workaround. Look into the cause of this.
+			// https://github.com/sindresorhus/Gifski/pull/262
+			// Skip incorrect out-of-range frames.
 			if result.actualTime.seconds < startTime {
 				return .success(true)
 			}

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -395,6 +395,10 @@ final class Gifski {
 					value: result.image.debugInfo
 				)
 			}
+			
+			if result.actualTime.seconds < startTime {
+				return .success(true)
+			}
 
 			let pixels: CGImage.Pixels
 			do {
@@ -405,6 +409,7 @@ final class Gifski {
 
 			do {
 				let frameNumber = result.completedCount - 1
+				assert(result.actualTime.seconds > 0 || frameNumber == 0)
 
 				try gifski?.addFrame(
 					pixelFormat: .rgba,


### PR DESCRIPTION
When using trimming the last frame has incorrect timestamp.