### PR TITLE
Fix green line sometimes occurring on the GIF

### DIFF
--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -295,10 +295,12 @@ final class Gifski {
 		generator.requestedTimeToleranceBefore = .zero
 		generator.requestedTimeToleranceAfter = .zero
 
+		// Disabled as it can create a green line on the side if the size is not a multiple of the original size. For example, when the orignal is 1080 and you want the size 112. However 108 does not create a green line. (macOS 12.5)
+		// https://github.com/sindresorhus/Gifski/pull/278
 		// This improves the performance a little bit.
-		if let dimensions = conversion.dimensions {
-			generator.maximumSize = CGSize(widthHeight: dimensions.longestSide)
-		}
+//		if let dimensions = conversion.dimensions {
+//			generator.maximumSize = CGSize(widthHeight: dimensions.longestSide)
+//		}
 
 		// Even though we enforce a minimum of 3 FPS in the GUI, a source video could have lower FPS, and we should allow that.
 		var fps = (conversion.frameRate.map(Double.init) ?? assetFrameRate).clamped(to: 0.1...Constants.allowedFrameRate.upperBound)

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -295,12 +295,7 @@ final class Gifski {
 		generator.requestedTimeToleranceBefore = .zero
 		generator.requestedTimeToleranceAfter = .zero
 
-		// Disabled as it can create a green line on the side if the size is not a multiple of the original size. For example, when the orignal is 1080 and you want the size 112. However 108 does not create a green line. (macOS 12.5)
-		// https://github.com/sindresorhus/Gifski/pull/278
-		// This improves the performance a little bit.
-//		if let dimensions = conversion.dimensions {
-//			generator.maximumSize = CGSize(widthHeight: dimensions.longestSide)
-//		}
+		// We are intentionally not setting a `generator.maximumSize` as it's buggy: https://github.com/sindresorhus/Gifski/pull/278
 
 		// Even though we enforce a minimum of 3 FPS in the GUI, a source video could have lower FPS, and we should allow that.
 		var fps = (conversion.frameRate.map(Double.init) ?? assetFrameRate).clamped(to: 0.1...Constants.allowedFrameRate.upperBound)


### PR DESCRIPTION
To reproduce, take the [this video](https://user-images.githubusercontent.com/170270/183291184-b53aa3b0-b4b4-4e58-89dd-97755e35dc4f.mp4) and set the size to 112 in the existing Gifski version. It will produce a GIF that is has the dimensions 111x112 (incorrect dimensions) and it also has a green line on the right side:  
![Heart Spin 1080](https://user-images.githubusercontent.com/170270/183291226-c7309073-18fa-4b70-9c7a-5dcda7b454de.gif)

I have confirmed that the green line happens before passing it to the gifski library.

However, if we disable `generator.maximumSize` as done in this PR, the GIF comes out with the correct dimensions and no artifacts:
![Heart Spin 1080](https://user-images.githubusercontent.com/170270/183291298-aaa888b9-e33e-4285-b058-d4f6f314b820.gif)

The GIF also comes out correct when the dimensions are 108 instead of 112, so it makes me think it has something to do with it not handling sizes well that are not multiples on the original size.
