### PR TITLE
Add m1-friendly swiftlint script to build phase.

### DIFF
--- a/Gifski.xcodeproj/project.pbxproj
+++ b/Gifski.xcodeproj/project.pbxproj
@@ -438,8 +438,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "swiftlint\n";
-			showEnvVarsInLog = 0;
+			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Gifski.xcodeproj/project.pbxproj
+++ b/Gifski.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "PATH=\"/opt/homebrew/bin/:${PATH}\"\nswiftlint\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Add m1-friendly swiftlint script to build phase. Homebrew on mac silicon has a different installation path (opt/homebreow), so this catches both m1 and x86 scenarios.

This script came from [an issue](https://github.com/realm/SwiftLint/issues/2992#issuecomment-771001634) on the swiftlint repository.

<img width="588" alt="image" src="https://user-images.githubusercontent.com/5067237/205069229-df81457b-3563-4320-816d-041b9e32cbe2.png">

Fixes #284 
