### PR TITLE
Crop Video part 2.

### DIFF
--- a/Gifski/Intents.swift
+++ b/Gifski/Intents.swift
@@ -243,16 +243,6 @@ struct CreateCropIntent: AppIntent {
 	}
 }
 
-enum ConvertOutputMode: String, AppEnum, CaseIterable, Codable, Hashable {
-	static var caseDisplayRepresentations: [Self: DisplayRepresentation] = [
-		.animatedGIF: DisplayRepresentation(title: "animated GIF"),
-		.preview: DisplayRepresentation(title: "a single frame GIF preview")
-	]
-	case animatedGIF
-	case preview
-	static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Output Mode")
-}
-
 struct ConvertIntent: AppIntent, ProgressReportingIntent {
 	static let title: LocalizedStringResource = "Convert Video to Animated GIF"
 


### PR DESCRIPTION
## Crop Video part 2.
- [x] The custom aspect ratio now lets me use the arrow-up key even though the actual rect does not change. It should probably stop when the crop rect cannot be changed anymore.
 - Now it automatically adjust the `IntTextField.minMax` range based on the current aspect ratio bounds.
- [x] Remove `ConvertOutputMode` because it is not used anymore
- [x] If I write 10 in the custom aspect ratio popover for the size width field, it now shows a validation popover, but it would be even nicer if it just reset to the smallest size. Because right now, if a user accidentally writes 10, they are stuck on it if they try the arrow keys. So it could reset when either changing focus or using arrow keys.
- [x] If I change the height with arrow keys and it hits the bottom, the text field does not stop, but the size in the rect stops and in the dropdown. They should be consistent about the limit. Maybe a solution here is to move the rect up to make space so it's able to expand in height.