### PR TITLE
fix frame flash on bounce #332

### DIFF
--- a/Gifski/GIFGenerator.swift
+++ b/Gifski/GIFGenerator.swift
@@ -180,7 +180,7 @@ actor GIFGenerator {
 					let timestampSlippage = actualTime - requestedTime
 					let actualReverseTimestamp = max(0, expectedReverseTimestamp + timestampSlippage.seconds)
 
-					// Prevent duplicate frame with the same frame number causing a unwanted frame at the end of the GIF.
+					// Prevent duplicate frame with the same frame number causing an unwanted frame at the end of the GIF.
 					if frameNumber != reverseFrameNumber {
 						try gifski?.addFrame(
 							image,

--- a/Gifski/GIFGenerator.swift
+++ b/Gifski/GIFGenerator.swift
@@ -180,11 +180,13 @@ actor GIFGenerator {
 					let timestampSlippage = actualTime - requestedTime
 					let actualReverseTimestamp = max(0, expectedReverseTimestamp + timestampSlippage.seconds)
 
-					try gifski?.addFrame(
-						image,
-						frameNumber: reverseFrameNumber,
-						presentationTimestamp: actualReverseTimestamp
-					)
+					if frameNumber != reverseFrameNumber {
+						try gifski?.addFrame(
+							image,
+							frameNumber: reverseFrameNumber,
+							presentationTimestamp: actualReverseTimestamp
+						)
+					}
 				}
 
 				index += 1

--- a/Gifski/GIFGenerator.swift
+++ b/Gifski/GIFGenerator.swift
@@ -180,6 +180,7 @@ actor GIFGenerator {
 					let timestampSlippage = actualTime - requestedTime
 					let actualReverseTimestamp = max(0, expectedReverseTimestamp + timestampSlippage.seconds)
 
+					// Prevent duplicate frame with the same frame number causing a unwanted frame at the end of the GIF.
 					if frameNumber != reverseFrameNumber {
 						try gifski?.addFrame(
 							image,


### PR DESCRIPTION
This fixes the frame flash when bounce is enabled. (fixes #332)

You can see the error here at about 5 seconds in (when the video switches from going backwards to going forwards)

https://github.com/user-attachments/assets/a8a513c1-81c7-40e5-b692-08aae59ed29f

Here is same video, with the same settings exported with this new version (as you can see, there is no flash):

https://github.com/user-attachments/assets/da2bdbe2-c645-41bf-ad3d-05448d0469f4

## Cause of the Error

When the GIF export uses bounce the order of the frames should be like this:
| Source Frame Number | GIF Frame Number |
|---------------------|-----------------|
| 0                   | 0               |
| 1                   | 1               |
| 2                   | 2               |
| 3                   | 3               |
| 4                   | 4               |
| 3                   | 5               |
| 2                   | 6               |
| 1                   | 7               |
| 0                   | 8               |

But the source of the bug, was that the frames were actually like this:

| Source Frame Number | GIF Frame Number |
|---------------------|-----------------|
| 0                   | 0               |
| 1                   | 1               |
| 2                   | 2               |
| 3                   | 3               |
| 4                   | 4               |
| 4 👈                 | 4 👈            |
| 3                   | 5               |
| 2                   | 6               |
| 1                   | 7               |
| 0                   | 8               |

The last frame was being added twice, to the same GIF output frame number. This freaked out `Gifksi` (the library, not this app) and caused it to place the frame at the end (when it technically `loops`). I also verified that the PTS is the same at both the last frame and the incorrect last frame.

According the `Gifski` docs [Frames with duplicate or out-of-order PTS will be skipped.](https://github.com/ImageOptim/gifski/blob/ca0ed80878b18d9160a5896dd917430e82dce4de/gifski.h#L187), so this appears to be a bug in the `Gifksi` library itself. The documented behavior is that the frame should skipped. (although I will say that it doesn't mention frameNumber, just PTS. So maybe duplicate frameNumber is undefined?) If you want, I can open an issue over an that repo and try to get it fixed. But, it seems kind of overkill because we don't need to add the duplicate frame anyways.

### Fix
Basically a one liner, just don't add the frame if it is a duplicate:
```swift
if frameNumber != reverseFrameNumber {
  try gifski?.addFrame(....)
}
```
Or if you'd rather, skip all bounce processing on the last frame:
```swift
if conversion.bounce && frameNumber < totalFrameCount - 1  {
....
```







